### PR TITLE
Feat/#25 evaluation onboarding

### DIFF
--- a/core/common/src/main/java/com/my/version/core/common/media/LrcConverter.kt
+++ b/core/common/src/main/java/com/my/version/core/common/media/LrcConverter.kt
@@ -1,12 +1,6 @@
 package com.my.version.core.common.media
 
-import android.content.Context
-import androidx.annotation.RawRes
-import androidx.core.content.ContextCompat
-import timber.log.Timber
 import java.io.BufferedReader
-import java.io.FileInputStream
-import java.io.FileReader
 import java.io.InputStream
 import java.io.InputStreamReader
 

--- a/core/common/src/main/java/com/my/version/core/common/media/LrcConverter.kt
+++ b/core/common/src/main/java/com/my/version/core/common/media/LrcConverter.kt
@@ -1,0 +1,40 @@
+package com.my.version.core.common.media
+
+import android.content.Context
+import androidx.annotation.RawRes
+import androidx.core.content.ContextCompat
+import timber.log.Timber
+import java.io.BufferedReader
+import java.io.FileInputStream
+import java.io.FileReader
+import java.io.InputStream
+import java.io.InputStreamReader
+
+object LrcConverter {
+    fun convertToLyricMap( inputStream: InputStream): LinkedHashMap<Long, String> =
+        linkedMapOf<Long, String>().apply {
+            val reader = BufferedReader(InputStreamReader(inputStream))
+            reader.forEachLine { line ->
+                val splitStrings = line.split("]")
+                val timeInMillis = convertToMillis(splitStrings[0].removePrefix("["))
+                val lyricString = splitStrings[1]
+
+                put(timeInMillis, lyricString)
+            }
+        }
+
+
+    private fun convertToMillis(timeString: String): Long {
+        val parts = timeString.split(":", ".", ignoreCase = false, limit = 4)
+
+        // 시, 분, 초, 밀리초를 개별적으로 파싱
+        val hours = parts[0].toInt()
+        val minutes = parts[1].toInt()
+        val seconds = parts[2].toInt()
+        val milliseconds = if (parts.size > 3) parts[3].toInt() else 0
+
+        // 각 값을 밀리초로 변환 후 합산
+        val totalMillis = (hours * 3600000L) + (minutes * 60000L) + (seconds * 1000L) + milliseconds*10L
+        return totalMillis
+    }
+}

--- a/core/common/src/main/java/com/my/version/core/common/media/MusicPlayer.kt
+++ b/core/common/src/main/java/com/my/version/core/common/media/MusicPlayer.kt
@@ -1,11 +1,15 @@
 package com.my.version.core.common.media
 
 import android.media.MediaPlayer
+import androidx.compose.runtime.mutableIntStateOf
 import java.io.File
 
 object MusicPlayer {
     private var mediaPlayer: MediaPlayer? = null
     private var isPaused = false
+
+    private var _audioLength = 0
+    val audioLength get() = _audioLength
 
     fun playMusic(
         file: File?,
@@ -18,6 +22,9 @@ object MusicPlayer {
             mediaPlayer = MediaPlayer().apply {
                 setDataSource(it.absolutePath)
                 prepare()
+                setOnPreparedListener {
+                    _audioLength = it.duration
+                }
                 setOnCompletionListener { setOnCompletion() }
             }
         }

--- a/core/common/src/main/java/com/my/version/core/common/media/MusicPlayer.kt
+++ b/core/common/src/main/java/com/my/version/core/common/media/MusicPlayer.kt
@@ -27,6 +27,8 @@ object MusicPlayer {
         }
     }
 
+    fun isPlaying(): Boolean = mediaPlayer?.isPlaying ?: false
+
     fun pauseMusic() {
         if (!isPaused && mediaPlayer != null) {
             mediaPlayer?.pause()

--- a/core/common/src/main/java/com/my/version/core/common/media/MusicPlayer.kt
+++ b/core/common/src/main/java/com/my/version/core/common/media/MusicPlayer.kt
@@ -1,0 +1,55 @@
+package com.my.version.core.common.media
+
+import android.media.MediaPlayer
+import java.io.File
+
+object MusicPlayer {
+    private var mediaPlayer: MediaPlayer? = null
+    private var isPaused = false
+
+    fun playMusic(file: File?) {
+        if(mediaPlayer?.isPlaying == true) {
+            stopMusic()
+        }
+        file?.let {
+            mediaPlayer = MediaPlayer().apply {
+                setDataSource(it.absolutePath)
+                prepare()
+                setOnCompletionListener {
+                    reset()
+                }
+            }
+        }
+        try {
+            mediaPlayer?.start()
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    fun pauseMusic() {
+        if (!isPaused && mediaPlayer != null) {
+            mediaPlayer?.pause()
+            isPaused = true
+        }
+    }
+
+    fun resumeAudio() {
+        if (isPaused && mediaPlayer != null) {
+            mediaPlayer?.start()
+            isPaused = false
+        }
+    }
+
+    fun stopMusic() {
+        if (mediaPlayer != null || isPaused) {
+            mediaPlayer?.run {
+                stop()
+                reset()
+                release()
+            }
+            mediaPlayer = null
+            isPaused = false
+        }
+    }
+}

--- a/core/common/src/main/java/com/my/version/core/common/media/MusicPlayer.kt
+++ b/core/common/src/main/java/com/my/version/core/common/media/MusicPlayer.kt
@@ -7,17 +7,18 @@ object MusicPlayer {
     private var mediaPlayer: MediaPlayer? = null
     private var isPaused = false
 
-    fun playMusic(file: File?) {
-        if(mediaPlayer?.isPlaying == true) {
+    fun playMusic(
+        file: File?,
+        setOnCompletion: () -> Unit = { mediaPlayer?.reset() },
+    ) {
+        if (mediaPlayer?.isPlaying == true) {
             stopMusic()
         }
         file?.let {
             mediaPlayer = MediaPlayer().apply {
                 setDataSource(it.absolutePath)
                 prepare()
-                setOnCompletionListener {
-                    reset()
-                }
+                setOnCompletionListener { setOnCompletion() }
             }
         }
         try {

--- a/core/common/src/main/java/com/my/version/core/common/media/MyVersionMediaRecorder.kt
+++ b/core/common/src/main/java/com/my/version/core/common/media/MyVersionMediaRecorder.kt
@@ -14,7 +14,7 @@ class MyVersionMediaRecorder @Inject constructor(
     init {
         mediaRecorder.apply {
             setAudioSource(MediaRecorder.AudioSource.MIC)
-            setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
+            setOutputFormat(MediaRecorder.OutputFormat.AMR_WB)
             setAudioEncoder(MediaRecorder.AudioEncoder.DEFAULT)
         }
     }

--- a/core/common/src/main/java/com/my/version/core/common/watch/StopWatch.kt
+++ b/core/common/src/main/java/com/my/version/core/common/watch/StopWatch.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -15,10 +16,10 @@ import java.util.Locale
 
 class StopWatch {
     var formattedTime by mutableStateOf("00:00")
+    var timeMillis = 0L
 
-    private var isActive = false
+    var isActive = false
 
-    private var timeMillis = 0L
     private var lastTimestamp = 0L
 
 
@@ -48,6 +49,22 @@ class StopWatch {
         lastTimestamp = 0L
         formattedTime = "00:00"
     }
+
+    fun startForLyrics() {
+        if(isActive) return
+
+        Timber.tag("lyrics").d("starting stopwatch for lyrics")
+
+        CoroutineScope(Dispatchers.Default).launch {
+            lastTimestamp = System.currentTimeMillis()
+            this@StopWatch.isActive = true
+
+            while(this@StopWatch.isActive) {
+                timeMillis = System.currentTimeMillis() - lastTimestamp
+            }
+        }
+    }
+
 
     private fun formatTime(timeMillis: Long): String {
         val localDateTime = LocalDateTime.ofInstant(

--- a/core/data/src/main/java/com/my/version/core/data/repositoryimpl/RecordRepositoryImpl.kt
+++ b/core/data/src/main/java/com/my/version/core/data/repositoryimpl/RecordRepositoryImpl.kt
@@ -3,7 +3,6 @@ package com.my.version.core.data.repositoryimpl
 import android.media.MediaRecorder
 import com.my.version.core.data.datasource.local.RecordDataSource
 import com.my.version.core.domain.repository.RecordRepository
-import timber.log.Timber
 import javax.inject.Inject
 
 class RecordRepositoryImpl @Inject constructor(
@@ -20,12 +19,13 @@ class RecordRepositoryImpl @Inject constructor(
             filePath = recordDataSource.getNewRecordingFileAbsolutePath(type)
 
             mediaRecorder?.let { recorder ->
-                recorder.setAudioSource(MediaRecorder.AudioSource.MIC)
-                recorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
-                recorder.setAudioEncoder(MediaRecorder.AudioEncoder.DEFAULT)
-                recorder.setOutputFile(filePath)
-                recorder.prepare()
-                Timber.tag("RecordTest").d("Initialized Recording")
+                with(recorder) {
+                    setAudioSource(MediaRecorder.AudioSource.MIC)
+                    setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
+                    setAudioEncoder(MediaRecorder.AudioEncoder.DEFAULT)
+                    setOutputFile(filePath)
+                    prepare()
+                }
             }
         }
     }
@@ -35,7 +35,6 @@ class RecordRepositoryImpl @Inject constructor(
 
     override fun startRecording() {
         if(!isRecording && mediaRecorder != null) {
-            Timber.tag("RecordTest").d("Started Recording")
             mediaRecorder?.start()
             isRecording = true
         }
@@ -60,7 +59,6 @@ class RecordRepositoryImpl @Inject constructor(
     override fun stopRecording() {
         if(isRecording && mediaRecorder != null) {
             try {
-                Timber.tag("RecordTest").d("Stopped Recording")
                 mediaRecorder?.stop()
             } catch (e: RuntimeException) {
                 e.printStackTrace()
@@ -71,10 +69,6 @@ class RecordRepositoryImpl @Inject constructor(
 
                 isRecording = false
                 isPaused = false
-
-                if(mediaRecorder == null) {
-                    Timber.tag("RecordTest").d("Released Recording")
-                }
             }
         }
     }

--- a/core/data/src/main/java/com/my/version/core/data/repositoryimpl/RecordRepositoryImpl.kt
+++ b/core/data/src/main/java/com/my/version/core/data/repositoryimpl/RecordRepositoryImpl.kt
@@ -15,16 +15,18 @@ class RecordRepositoryImpl @Inject constructor(
     private var isPaused = false
 
     override fun initMediaRecorder(type: String?) {
-        mediaRecorder = recordDataSource.createNewMediaRecord()
-        filePath = recordDataSource.getNewRecordingFileAbsolutePath(type)
+        if(!isRecording) {
+            mediaRecorder = recordDataSource.createNewMediaRecord()
+            filePath = recordDataSource.getNewRecordingFileAbsolutePath(type)
 
-        mediaRecorder?.let { recorder ->
-            recorder.setAudioSource(MediaRecorder.AudioSource.MIC)
-            recorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
-            recorder.setAudioEncoder(MediaRecorder.AudioEncoder.DEFAULT)
-            recorder.setOutputFile(filePath)
-            recorder.prepare()
-            Timber.tag("RecordTest").d("Initialized Recording")
+            mediaRecorder?.let { recorder ->
+                recorder.setAudioSource(MediaRecorder.AudioSource.MIC)
+                recorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
+                recorder.setAudioEncoder(MediaRecorder.AudioEncoder.DEFAULT)
+                recorder.setOutputFile(filePath)
+                recorder.prepare()
+                Timber.tag("RecordTest").d("Initialized Recording")
+            }
         }
     }
 

--- a/core/domain/src/main/java/com/my/version/core/domain/entity/EvaluationResult.kt
+++ b/core/domain/src/main/java/com/my/version/core/domain/entity/EvaluationResult.kt
@@ -1,0 +1,7 @@
+package com.my.version.core.domain.entity
+
+data class EvaluationResult(
+    val title: String = "",
+    val date: String = "",
+    val similarity: Double = 0.0,
+)

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/component/LyricView.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/component/LyricView.kt
@@ -1,11 +1,9 @@
 package com.my.version.feature.evaluate.component
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/component/LyricView.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/component/LyricView.kt
@@ -1,0 +1,46 @@
+package com.my.version.feature.evaluate.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.my.version.core.designsystem.theme.MyVersionMain
+import com.my.version.core.designsystem.theme.White
+
+@Composable
+fun LyricView(
+    timeStamp: Long,
+    modifier: Modifier = Modifier,
+    lyrics: Map<Long, String> = emptyMap()
+) {
+    val scrollState = rememberScrollState()
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .verticalScroll(
+                state = scrollState
+            ),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        for ((time, lyric) in lyrics.entries.toList()) {
+            val color = if(time == timeStamp) MyVersionMain else White
+            Text(
+                text = lyric,
+                color = color,
+                style = MaterialTheme.typography.titleMedium
+            )
+
+            Spacer(modifier = Modifier.height(6.dp))
+        }
+    }
+}

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/main/EvaluationScreen.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/main/EvaluationScreen.kt
@@ -53,6 +53,8 @@ import com.my.version.feature.evaluate.main.state.EvaluationUiState
 
 @Composable
 fun EvaluationRoute(
+    navigateToSelect: () -> Unit,
+    navigateToResult: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: EvaluationViewModel = hiltViewModel()
 ) {
@@ -61,16 +63,18 @@ fun EvaluationRoute(
 
     EvaluationScreen(
         modifier = modifier,
-        uiState = uiState
+        uiState = uiState,
+        onCreateClicked = navigateToSelect,
+        onEvaluationSelected = navigateToSelect
     )
 }
 
 @Composable
 private fun EvaluationScreen(
     uiState: EvaluationUiState,
+    onCreateClicked: () -> Unit,
+    onEvaluationSelected: () -> Unit,
     modifier: Modifier = Modifier,
-    onCreateClicked: () -> Unit = {},
-    onEvaluationSelected: () -> Unit = {}
 ) {
     val commonModifier = Modifier.padding(horizontal = 20.dp)
     var isSelected by remember { mutableStateOf(false) }
@@ -81,7 +85,7 @@ private fun EvaluationScreen(
         NewCreationTopAppBar(
             title = stringResource(id = R.string.evaluation_topbar_main),
             textStyle = MaterialTheme.typography.labelLarge,
-            onClick = {}
+            onClick = onCreateClicked
         )
 
         BasicSpacer(height = 30.dp)
@@ -175,6 +179,8 @@ fun SuccessScreenPreview() {
     MyVersionTheme {
         EvaluationScreen(
             uiState = EvaluationUiState(),
+            onCreateClicked = {},
+            onEvaluationSelected = {},
             modifier = Modifier.background(MyVersionBackground)
         )
     }

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/main/EvaluationScreen.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/main/EvaluationScreen.kt
@@ -1,6 +1,5 @@
 package com.my.version.feature.evaluate.main
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -13,7 +12,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -35,7 +33,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.my.version.core.common.state.UiState
 import com.my.version.core.designsystem.component.button.SortingButton
 import com.my.version.core.designsystem.component.divider.BasicSpacer
-import com.my.version.core.designsystem.component.divider.TitleWithDivider
 import com.my.version.core.designsystem.component.item.MyVersionVerticalItem
 import com.my.version.core.designsystem.component.topappbar.NewCreationTopAppBar
 import com.my.version.core.designsystem.theme.Black
@@ -44,9 +41,7 @@ import com.my.version.core.designsystem.theme.Grey400
 import com.my.version.core.designsystem.theme.MyVersionBackground
 import com.my.version.core.designsystem.theme.MyVersionTheme
 import com.my.version.core.designsystem.theme.White
-import com.my.version.core.designsystem.type.TempItem
 import com.my.version.core.designsystem.type.VerticalItemType
-import com.my.version.core.designsystem.type.tempList1
 import com.my.version.core.domain.entity.EvaluationResult
 import com.my.version.feature.evaluate.R
 import com.my.version.feature.evaluate.main.state.EvaluationUiState

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/main/EvaluationScreen.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/main/EvaluationScreen.kt
@@ -2,8 +2,10 @@ package com.my.version.feature.evaluate.main
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,6 +15,7 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -27,74 +30,124 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.my.version.core.common.state.UiState
 import com.my.version.core.designsystem.component.button.SortingButton
+import com.my.version.core.designsystem.component.divider.BasicSpacer
 import com.my.version.core.designsystem.component.divider.TitleWithDivider
 import com.my.version.core.designsystem.component.item.MyVersionVerticalItem
 import com.my.version.core.designsystem.component.topappbar.NewCreationTopAppBar
 import com.my.version.core.designsystem.theme.Black
 import com.my.version.core.designsystem.theme.Grey300
+import com.my.version.core.designsystem.theme.Grey400
 import com.my.version.core.designsystem.theme.MyVersionBackground
 import com.my.version.core.designsystem.theme.MyVersionTheme
+import com.my.version.core.designsystem.theme.White
 import com.my.version.core.designsystem.type.TempItem
 import com.my.version.core.designsystem.type.VerticalItemType
 import com.my.version.core.designsystem.type.tempList1
+import com.my.version.core.domain.entity.EvaluationResult
 import com.my.version.feature.evaluate.R
+import com.my.version.feature.evaluate.main.state.EvaluationUiState
 
 @Composable
 fun EvaluationRoute(
     modifier: Modifier = Modifier,
     viewModel: EvaluationViewModel = hiltViewModel()
 ) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle(lifecycleOwner)
+
     EvaluationScreen(
-        modifier = modifier
+        modifier = modifier,
+        uiState = uiState
     )
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun EvaluationScreen(
-    modifier: Modifier,
-    evaluationList: List<TempItem> = emptyList()
+    uiState: EvaluationUiState,
+    modifier: Modifier = Modifier,
+    onCreateClicked: () -> Unit = {},
+    onEvaluationSelected: () -> Unit = {}
 ) {
+    val commonModifier = Modifier.padding(horizontal = 20.dp)
     var isSelected by remember { mutableStateOf(false) }
 
-    Column {
+    Column(
+        modifier = modifier
+    ) {
         NewCreationTopAppBar(
             title = stringResource(id = R.string.evaluation_topbar_main),
             textStyle = MaterialTheme.typography.labelLarge,
             onClick = {}
         )
-        Box(
-            modifier
+
+        BasicSpacer(height = 30.dp)
+
+        Row(
+            modifier = commonModifier
                 .fillMaxWidth()
                 .wrapContentHeight()
-                .padding(horizontal = 20.dp),
-            contentAlignment = Alignment.TopEnd,
+                .padding(horizontal = 10.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            TitleWithDivider(
+            Text(
                 text = stringResource(id = R.string.evaluation_main_title),
-                textStyle = MaterialTheme.typography.titleSmall,
+                style = MaterialTheme.typography.titleSmall,
+                color = White
             )
             SortingButton(
                 isSelected = isSelected,
                 text = "최신순",
                 onClick = { isSelected = !isSelected },
-                modifier = modifier.padding(20.dp)
             )
         }
 
-        if (evaluationList.isEmpty()) {
-            EmptyScreen()
-        } else {
-            SuccessScreen()
+        HorizontalDivider(
+            thickness = 1.dp,
+            color = Grey400,
+            modifier = commonModifier
+                .padding(vertical = 6.dp)
+        )
+
+        when(uiState.loadState) {
+            is UiState.Loading -> {}
+            is UiState.Empty -> EmptyScreen(modifier = commonModifier)
+            is UiState.Failure -> {}
+            is UiState.Success -> {
+                SuccessScreen(
+                    evaluationList = uiState.loadState.data,
+                    modifier = commonModifier
+                )
+            }
         }
+    }
+}
+
+@Composable
+private fun EmptyScreen(
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "You have not created any evaluation",
+            textAlign = TextAlign.Center,
+            color = Grey300,
+            style = MaterialTheme.typography.titleMedium,
+        )
     }
 }
 
 @Composable
 private fun SuccessScreen(
     modifier: Modifier = Modifier,
-    evaluationList: List<TempItem> = emptyList()
+    evaluationList: List<EvaluationResult> = emptyList()
 ) {
     LazyColumn(
         modifier = modifier
@@ -107,7 +160,7 @@ private fun SuccessScreen(
                 iconColor = Black,
                 onClick = { /*TODO*/ },
                 title = cover.title,
-                subTitle = cover.body
+                subTitle = cover.date
             )
             if (evaluationList.last() != cover) {
                 Spacer(modifier = Modifier.height(16.dp))
@@ -116,29 +169,12 @@ private fun SuccessScreen(
     }
 }
 
-@Composable
-private fun EmptyScreen(
-    modifier: Modifier = Modifier
-) {
-    Box(
-        modifier = modifier.fillMaxSize(),
-        //contentAlignment = Alignment.TopCenter
-    ) {
-        Text(
-            text = "You have not created any evaluation",
-            textAlign = TextAlign.Center,
-            color = Grey300,
-            style = MaterialTheme.typography.titleMedium,
-        )
-    }
-}
-
 @Preview(showBackground = true, showSystemUi = true)
 @Composable
 fun SuccessScreenPreview() {
     MyVersionTheme {
         EvaluationScreen(
-            evaluationList = tempList1,
+            uiState = EvaluationUiState(),
             modifier = Modifier.background(MyVersionBackground)
         )
     }

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/main/EvaluationViewModel.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/main/EvaluationViewModel.kt
@@ -1,10 +1,18 @@
 package com.my.version.feature.evaluate.main
 
 import androidx.lifecycle.ViewModel
+import com.my.version.feature.evaluate.main.state.EvaluationUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 
+@HiltViewModel
 class EvaluationViewModel @Inject constructor(
 
 ): ViewModel() {
+    private val _uiState = MutableStateFlow(EvaluationUiState())
+    val uiState = _uiState.asStateFlow()
+
 
 }

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/main/navigation/EvaluationNavigation.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/main/navigation/EvaluationNavigation.kt
@@ -12,11 +12,15 @@ import kotlinx.serialization.Serializable
 fun NavController.navigateToEvaluation(navOptions: NavOptions? = null) = navigate(Evaluation, navOptions)
 
 fun NavGraphBuilder.evaluationScreen(
-    modifier: Modifier
+    modifier: Modifier,
+    navigateToSelect: () -> Unit,
+    navigateToResult: () -> Unit,
 ) {
     composable<Evaluation>{
         EvaluationRoute(
-            modifier = modifier
+            modifier = modifier,
+            navigateToSelect = navigateToSelect,
+            navigateToResult = navigateToResult
         )
     }
 }

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/main/state/EvaluationUiState.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/main/state/EvaluationUiState.kt
@@ -1,0 +1,8 @@
+package com.my.version.feature.evaluate.main.state
+
+import com.my.version.core.common.state.UiState
+import com.my.version.core.domain.entity.EvaluationResult
+
+data class EvaluationUiState(
+    val loadState: UiState<List<EvaluationResult>> = UiState.Loading
+)

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordScreen.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordScreen.kt
@@ -46,6 +46,8 @@ import com.my.version.core.designsystem.R as DesignSystemR
 
 @Composable
 fun EvaluationRecordRoute(
+    navigateUp: () -> Unit,
+    navigateToEvaluationUpload: (String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: EvaluationRecordViewModel = hiltViewModel()
 ) {
@@ -60,6 +62,12 @@ fun EvaluationRecordRoute(
     if(uiState.songLyrics.isNotEmpty()) {
         EvaluationRecordScreen(
             modifier = modifier,
+            onPressNextButton = {
+                viewModel.getRecordFilePath()?.let {
+                    navigateToEvaluationUpload(it)
+                }
+            },
+            onPressBackButton = navigateUp,
             onPlayMusic = {
                 viewModel.playMusic()
                 viewModel.startRecording()
@@ -75,6 +83,8 @@ fun EvaluationRecordRoute(
 
 @Composable
 fun EvaluationRecordScreen(
+    onPressNextButton: () -> Unit,
+    onPressBackButton: () -> Unit,
     onPlayMusic: () -> Unit,
     onStopMusic: () -> Unit,
     uiState: EvaluationRecordUiState,
@@ -89,7 +99,7 @@ fun EvaluationRecordScreen(
         modifier = modifier
     ) {
         NavigateUpTopAppBar(
-            onNavigateUp = { },
+            onNavigateUp = onPressBackButton,
             title = stringResource(id = R.string.evaluation_topbar_record)
         )
 
@@ -156,8 +166,7 @@ fun EvaluationRecordScreen(
 
             MyVersionBasicIconButton(
                 icon = DesignSystemR.drawable.ic_stop,
-                onClick = onStopMusic
-                ,
+                onClick = onStopMusic,
                 color = Grey200
             )
         }
@@ -169,10 +178,11 @@ fun EvaluationRecordScreen(
             contentAlignment = Alignment.BottomCenter
         ) {
             RectangleButton(
-                isEnabled = false,
+                isEnabled = uiState.isNextEnabled,
                 text = "Next",
                 textStyle = MaterialTheme.typography.titleMedium,
                 innerPadding = 20,
+                onClick = onPressNextButton,
                 modifier = Modifier.fillMaxWidth()
             )
         }
@@ -185,6 +195,8 @@ private fun EvaluationRecordScreenPreview() {
     MyVersionTheme {
         EvaluationRecordScreen(
             modifier = Modifier.background(MyVersionBackground),
+            onPressNextButton = {},
+            onPressBackButton = {},
             onPlayMusic = {},
             onStopMusic = {},
             uiState = EvaluationRecordUiState()

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordScreen.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordScreen.kt
@@ -29,12 +29,19 @@ import com.my.version.core.designsystem.component.button.MyVersionBasicIconButto
 import com.my.version.core.designsystem.component.button.RectangleButton
 import com.my.version.core.designsystem.component.divider.MyVersionHorizontalDivider
 import com.my.version.core.designsystem.component.divider.TitleWithDivider
+import com.my.version.core.designsystem.component.topappbar.NavigateUpTopAppBar
 import com.my.version.core.designsystem.theme.Grey200
 import com.my.version.core.designsystem.theme.MyVersionBackground
 import com.my.version.core.designsystem.theme.MyVersionTheme
 import com.my.version.core.designsystem.theme.White
 import com.my.version.feature.evaluate.R
 import com.my.version.core.designsystem.R as DesignSystemR
+
+/**
+ * 로직
+ * 1. 녹음 버튼을 누른다
+ * 2. 카운트다운 3과 함께 녹음 및 음악 재생을 실행한다.
+ */
 
 @Composable
 fun EvaluationRecordRoute(
@@ -43,6 +50,14 @@ fun EvaluationRecordRoute(
 ) {
     EvaluationRecordScreen(
         modifier = modifier,
+        onPlayMusic = {
+            viewModel.startRecording()
+            //viewModel.playMusic()
+        },
+        onStopMusic = {
+            viewModel.stopRecording()
+            //viewModel.stopMusic()
+        },
         lyrics = listOf(
             "sdasdasdasd",
             "asdsadasdsad",
@@ -70,8 +85,10 @@ fun EvaluationRecordRoute(
 
 @Composable
 fun EvaluationRecordScreen(
+    onPlayMusic: () -> Unit,
+    onStopMusic: () -> Unit,
+    lyrics: List<String>,
     modifier: Modifier = Modifier,
-    lyrics: List<String>
 ) {
     val commonModifier = Modifier
         .fillMaxWidth()
@@ -80,8 +97,13 @@ fun EvaluationRecordScreen(
     Column(
         modifier = modifier
     ) {
+        NavigateUpTopAppBar(
+            onNavigateUp = { },
+            title = stringResource(id = R.string.evaluation_topbar_record)
+        )
+
         TitleWithDivider(
-            text = stringResource(id = R.string.evaluation_main_title),
+            text = stringResource(id = R.string.evaluation_on_boarding_title2),
             textStyle = MaterialTheme.typography.titleMedium,
             modifier = commonModifier
         )
@@ -130,14 +152,14 @@ fun EvaluationRecordScreen(
             ) {
                 MyVersionBasicIconButton(
                     icon = DesignSystemR.drawable.ic_record_32,
-                    onClick = { /*TODO*/ },
+                    onClick = onPlayMusic,
                     color = Color.Red
                 )
             }
 
             MyVersionBasicIconButton(
                 icon = DesignSystemR.drawable.ic_stop,
-                onClick = { /*TODO*/ },
+                onClick = onStopMusic,
                 color = Grey200
             )
         }
@@ -171,7 +193,9 @@ private fun EvaluationRecordScreenPreview() {
                 "fsdabfahdfadsf",
                 "dafsdfafadf",
                 "safdsfsgfsdg"
-            )
+            ),
+            onPlayMusic = {},
+            onStopMusic = {}
         )
     }
 }

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordScreen.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordScreen.kt
@@ -41,7 +41,7 @@ import com.my.version.core.designsystem.theme.MyVersionMain
 import com.my.version.core.designsystem.theme.MyVersionTheme
 import com.my.version.core.designsystem.theme.White
 import com.my.version.feature.evaluate.R
-import com.my.version.feature.evaluate.record.model.EvaluationRecordUiState
+import com.my.version.feature.evaluate.record.state.EvaluationRecordUiState
 import com.my.version.core.designsystem.R as DesignSystemR
 
 @Composable

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordScreen.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordScreen.kt
@@ -63,9 +63,10 @@ fun EvaluationRecordRoute(
         EvaluationRecordScreen(
             modifier = modifier,
             onPressNextButton = {
-                viewModel.getRecordFilePath()?.let {
+                navigateToEvaluationUpload("")
+                /*viewModel.getRecordFilePath()?.let {
                     navigateToEvaluationUpload(it)
-                }
+                }*/
             },
             onPressBackButton = navigateUp,
             onPlayMusic = {

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordScreen.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,19 +11,25 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.my.version.core.common.media.LrcConverter
 import com.my.version.core.designsystem.component.button.MyVersionBasicIconButton
 import com.my.version.core.designsystem.component.button.RectangleButton
 import com.my.version.core.designsystem.component.divider.MyVersionHorizontalDivider
@@ -32,64 +37,50 @@ import com.my.version.core.designsystem.component.divider.TitleWithDivider
 import com.my.version.core.designsystem.component.topappbar.NavigateUpTopAppBar
 import com.my.version.core.designsystem.theme.Grey200
 import com.my.version.core.designsystem.theme.MyVersionBackground
+import com.my.version.core.designsystem.theme.MyVersionMain
 import com.my.version.core.designsystem.theme.MyVersionTheme
 import com.my.version.core.designsystem.theme.White
 import com.my.version.feature.evaluate.R
+import com.my.version.feature.evaluate.record.model.EvaluationRecordUiState
 import com.my.version.core.designsystem.R as DesignSystemR
-
-/**
- * 로직
- * 1. 녹음 버튼을 누른다
- * 2. 카운트다운 3과 함께 녹음 및 음악 재생을 실행한다.
- */
 
 @Composable
 fun EvaluationRecordRoute(
     modifier: Modifier = Modifier,
     viewModel: EvaluationRecordViewModel = hiltViewModel()
 ) {
-    EvaluationRecordScreen(
-        modifier = modifier,
-        onPlayMusic = {
-            viewModel.startRecording()
-            //viewModel.playMusic()
-        },
-        onStopMusic = {
-            viewModel.stopRecording()
-            //viewModel.stopMusic()
-        },
-        lyrics = listOf(
-            "sdasdasdasd",
-            "asdsadasdsad",
-            "fsdabfahdfadsf",
-            "dafsdfafadf",
-            "safdsfsgfsdg",
-            "fsdabfahdfadsf",
-            "dafsdfafadf",
-            "safdsfsgfsdg",
-            "fsdabfahdfadsf",
-            "dafsdfafadf",
-            "safdsfsgfsdg",
-            "fsdabfahdfadsf",
-            "dafsdfafadf",
-            "safdsfsgfsdg",
-            "fsdabfahdfadsf",
-            "dafsdfafadf",
-            "safdsfsgfsdg",
-            "fsdabfahdfadsf",
-            "dafsdfafadf",
-            "safdsfsgfsdg"
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle(lifecycleOwner)
+
+    LaunchedEffect(true) {
+        viewModel.updateSongLyrics(LrcConverter.convertToLyricMap(context.resources.openRawResource(R.raw.ditto)))
+    }
+
+    if(uiState.songLyrics.isNotEmpty()) {
+        EvaluationRecordScreen(
+            modifier = modifier,
+            onPlayMusic = {
+                viewModel.playMusic()
+                viewModel.startRecording()
+            },
+            onStopMusic = {
+                viewModel.stopMusic()
+                viewModel.stopRecording()
+            },
+            uiState = uiState
         )
-    )
+    }
 }
 
 @Composable
 fun EvaluationRecordScreen(
     onPlayMusic: () -> Unit,
     onStopMusic: () -> Unit,
-    lyrics: List<String>,
+    uiState: EvaluationRecordUiState,
     modifier: Modifier = Modifier,
 ) {
+    val scrollState = rememberScrollState()
     val commonModifier = Modifier
         .fillMaxWidth()
         .padding(horizontal = 20.dp)
@@ -108,22 +99,28 @@ fun EvaluationRecordScreen(
             modifier = commonModifier
         )
 
-        LazyColumn(
-            modifier = commonModifier
-                .height(450.dp),
-            contentPadding = PaddingValues(20.dp),
+
+        Column(
+            modifier = Modifier
+                .height(450.dp)
+                .fillMaxWidth()
+                .verticalScroll(
+                    state = scrollState
+                ),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            items(lyrics) { line ->
+            for ((time, lyric) in uiState.songLyrics.entries.toList()) {
+                val color = if(time == uiState.currentTimeStamp) MyVersionMain else White
                 Text(
-                    text = line,
-                    color = White,
+                    text = lyric,
+                    color = color,
                     style = MaterialTheme.typography.titleMedium
                 )
 
                 Spacer(modifier = Modifier.height(6.dp))
             }
         }
+
 
         MyVersionHorizontalDivider(
             modifier = commonModifier
@@ -159,7 +156,8 @@ fun EvaluationRecordScreen(
 
             MyVersionBasicIconButton(
                 icon = DesignSystemR.drawable.ic_stop,
-                onClick = onStopMusic,
+                onClick = onStopMusic
+                ,
                 color = Grey200
             )
         }
@@ -187,15 +185,9 @@ private fun EvaluationRecordScreenPreview() {
     MyVersionTheme {
         EvaluationRecordScreen(
             modifier = Modifier.background(MyVersionBackground),
-            lyrics = listOf(
-                "sdasdasdasd",
-                "asdsadasdsad",
-                "fsdabfahdfadsf",
-                "dafsdfafadf",
-                "safdsfsgfsdg"
-            ),
             onPlayMusic = {},
-            onStopMusic = {}
+            onStopMusic = {},
+            uiState = EvaluationRecordUiState()
         )
     }
 }

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordViewModel.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordViewModel.kt
@@ -6,53 +6,100 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.my.version.core.common.media.MusicPlayer
-import com.my.version.core.common.media.MyVersionMediaPlayer
+import com.my.version.core.common.watch.StopWatch
 import com.my.version.core.domain.entity.MusicAudioFile
 import com.my.version.core.domain.repository.MusicLocalRepository
 import com.my.version.core.domain.repository.RecordRepository
+import com.my.version.feature.evaluate.record.model.EvaluationRecordUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.io.File
 import javax.inject.Inject
 
 @HiltViewModel
 class EvaluationRecordViewModel @Inject constructor(
     private val musicLocalRepository: MusicLocalRepository,
     private val recordRepository: RecordRepository
-): ViewModel() {
-    private var music: MusicAudioFile? = null
+) : ViewModel() {
+    private var _uiState = MutableStateFlow(EvaluationRecordUiState())
+    val uiState = _uiState.asStateFlow()
+
     private var isRecording by mutableStateOf(false)
+    private var stopWatch = StopWatch()
+
 
     init {
-        getMusicList()
-    }
-
-    private fun getMusicList() = viewModelScope.launch {
-        val musicList = musicLocalRepository.getMusicAudioList()
-        music = musicList[1]
-    }
-
-    fun playMusic() = viewModelScope.launch {
-        try {
-            MusicPlayer.playMusic(music?.audio)
-        } catch (e: Exception) {
-            e.printStackTrace()
+        viewModelScope.launch {
+            val musicList = musicLocalRepository.getMusicAudioList()
+            updateMusic(musicList[3])
         }
     }
 
-
-    fun stopMusic() = viewModelScope.launch {
-        MusicPlayer.stopMusic()
+    fun updateMusic(music: MusicAudioFile) = _uiState.update { currentState ->
+        currentState.copy(
+            music = music
+        )
     }
 
-    fun getFilePath(): String = recordRepository.getFilePath()?:""
+    fun updateSongLyrics(lyric: LinkedHashMap<Long, String>) = _uiState.update { currentState ->
+        currentState.copy(
+            songLyrics = lyric
+        )
+    }
+
+    private fun updateCurrentTimeStamp(timeMillis: Long) =
+        viewModelScope.launch(Dispatchers.Default) {
+            _uiState.update { currentState ->
+                currentState.copy(
+                    currentTimeStamp = timeMillis
+                )
+            }
+        }
+
+    fun playMusic() = viewModelScope.launch(Dispatchers.Default) {
+        if (isRecording) return@launch
+
+        try {
+            MusicPlayer.playMusic(_uiState.value.music?.audio)
+            var lyricIndex = 0
+            if (MusicPlayer.isPlaying())
+                stopWatch.startForLyrics()
+
+            while (MusicPlayer.isPlaying()) {
+                try {
+                    if ((_uiState.value.songLyrics.keys.elementAt(lyricIndex)) < stopWatch.timeMillis) {
+                        updateCurrentTimeStamp(
+                            _uiState.value.songLyrics.keys.elementAt(
+                                lyricIndex
+                            )
+                        )
+                        lyricIndex += 1
+                    }
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                    break
+                }
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+
+    }
+
+
+    fun stopMusic() = viewModelScope.launch(Dispatchers.Default) {
+        if(isRecording) {
+            MusicPlayer.stopMusic()
+            stopWatch.reset()
+        }
+    }
 
     fun startRecording() = viewModelScope.launch(Dispatchers.IO) {
-        if(!isRecording) {
+        if (!isRecording) {
             isRecording = true
             recordRepository.initMediaRecorder(Environment.DIRECTORY_RECORDINGS)
             recordRepository.startRecording()
@@ -60,9 +107,12 @@ class EvaluationRecordViewModel @Inject constructor(
     }
 
     fun stopRecording() = viewModelScope.launch(Dispatchers.IO) {
-        if(isRecording) {
+        if (isRecording) {
             isRecording = false
             recordRepository.stopRecording()
+            updateCurrentTimeStamp(0)
         }
     }
+
+
 }

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordViewModel.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordViewModel.kt
@@ -35,7 +35,7 @@ class EvaluationRecordViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             val musicList = musicLocalRepository.getMusicAudioList()
-            updateMusic(musicList[3])
+            updateMusic(musicList[1])
         }
     }
 

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordViewModel.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordViewModel.kt
@@ -1,10 +1,68 @@
 package com.my.version.feature.evaluate.record
 
+import android.os.Environment
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.my.version.core.common.media.MusicPlayer
+import com.my.version.core.common.media.MyVersionMediaPlayer
+import com.my.version.core.domain.entity.MusicAudioFile
+import com.my.version.core.domain.repository.MusicLocalRepository
+import com.my.version.core.domain.repository.RecordRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.io.File
 import javax.inject.Inject
 
+@HiltViewModel
 class EvaluationRecordViewModel @Inject constructor(
-
+    private val musicLocalRepository: MusicLocalRepository,
+    private val recordRepository: RecordRepository
 ): ViewModel() {
+    private var music: MusicAudioFile? = null
+    private var isRecording by mutableStateOf(false)
 
+    init {
+        getMusicList()
+    }
+
+    private fun getMusicList() = viewModelScope.launch {
+        val musicList = musicLocalRepository.getMusicAudioList()
+        music = musicList[1]
+    }
+
+    fun playMusic() = viewModelScope.launch {
+        try {
+            MusicPlayer.playMusic(music?.audio)
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+
+    fun stopMusic() = viewModelScope.launch {
+        MusicPlayer.stopMusic()
+    }
+
+    fun getFilePath(): String = recordRepository.getFilePath()?:""
+
+    fun startRecording() = viewModelScope.launch(Dispatchers.IO) {
+        if(!isRecording) {
+            isRecording = true
+            recordRepository.initMediaRecorder(Environment.DIRECTORY_RECORDINGS)
+            recordRepository.startRecording()
+        }
+    }
+
+    fun stopRecording() = viewModelScope.launch(Dispatchers.IO) {
+        if(isRecording) {
+            isRecording = false
+            recordRepository.stopRecording()
+        }
+    }
 }

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordViewModel.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordViewModel.kt
@@ -11,7 +11,7 @@ import com.my.version.core.common.watch.StopWatch
 import com.my.version.core.domain.entity.MusicAudioFile
 import com.my.version.core.domain.repository.MusicLocalRepository
 import com.my.version.core.domain.repository.RecordRepository
-import com.my.version.feature.evaluate.record.model.EvaluationRecordUiState
+import com.my.version.feature.evaluate.record.state.EvaluationRecordUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordViewModel.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordViewModel.kt
@@ -60,11 +60,27 @@ class EvaluationRecordViewModel @Inject constructor(
             }
         }
 
+    private fun updateIsNextEnabled(isEnabled: Boolean) = viewModelScope.launch {
+        _uiState.update { currentState ->
+            currentState.copy(
+                isNextEnabled = isEnabled
+            )
+        }
+    }
+
     fun playMusic() = viewModelScope.launch(Dispatchers.Default) {
         if (isRecording) return@launch
 
         try {
-            MusicPlayer.playMusic(_uiState.value.music?.audio)
+            MusicPlayer.playMusic(
+                file = _uiState.value.music?.audio,
+                setOnCompletion = {
+                    stopRecording()
+                    stopMusic()
+                    updateCurrentTimeStamp(0)
+                    updateIsNextEnabled(true)
+                }
+            )
             var lyricIndex = 0
             if (MusicPlayer.isPlaying())
                 stopWatch.startForLyrics()
@@ -87,12 +103,11 @@ class EvaluationRecordViewModel @Inject constructor(
         } catch (e: Exception) {
             e.printStackTrace()
         }
-
     }
 
 
     fun stopMusic() = viewModelScope.launch(Dispatchers.Default) {
-        if(isRecording) {
+        if (isRecording) {
             MusicPlayer.stopMusic()
             stopWatch.reset()
         }
@@ -114,5 +129,5 @@ class EvaluationRecordViewModel @Inject constructor(
         }
     }
 
-
+    fun getRecordFilePath(): String? = recordRepository.getFilePath()
 }

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/model/EvaluationRecordUiState.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/model/EvaluationRecordUiState.kt
@@ -5,5 +5,6 @@ import com.my.version.core.domain.entity.MusicAudioFile
 data class EvaluationRecordUiState(
     val music: MusicAudioFile?= null,
     val songLyrics: Map<Long, String> = mapOf(),
-    val currentTimeStamp: Long = 0L
+    val currentTimeStamp: Long = 0L,
+    val isNextEnabled: Boolean = false,
 )

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/model/EvaluationRecordUiState.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/model/EvaluationRecordUiState.kt
@@ -1,0 +1,9 @@
+package com.my.version.feature.evaluate.record.model
+
+import com.my.version.core.domain.entity.MusicAudioFile
+
+data class EvaluationRecordUiState(
+    val music: MusicAudioFile?= null,
+    val songLyrics: Map<Long, String> = mapOf(),
+    val currentTimeStamp: Long = 0L
+)

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/navigation/EvaluationRecordNavigation.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/navigation/EvaluationRecordNavigation.kt
@@ -14,11 +14,15 @@ import kotlinx.serialization.Serializable
 fun NavController.navigateToEvaluationRecord(navOptions: NavOptions? = null) = navigate(EvaluationRecord, navOptions)
 
 fun NavGraphBuilder.evaluationRecordScreen(
-    modifier: Modifier
+    navigateUp: () -> Unit,
+    navigateToEvaluationUpload: (String) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     composable<EvaluationRecord>{
         EvaluationRecordRoute(
-            modifier = modifier
+            modifier = modifier,
+            navigateUp = navigateUp,
+            navigateToEvaluationUpload = navigateToEvaluationUpload,
         )
     }
 }

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/navigation/EvaluationRecordNavigation.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/navigation/EvaluationRecordNavigation.kt
@@ -6,8 +6,6 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.my.version.core.common.navigation.Route
-import com.my.version.feature.evaluate.select.EvaluationSelectRoute
-import com.my.version.feature.evaluate.main.navigation.Evaluation
 import com.my.version.feature.evaluate.record.EvaluationRecordRoute
 import kotlinx.serialization.Serializable
 

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/state/EvaluationRecordUiState.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/state/EvaluationRecordUiState.kt
@@ -1,4 +1,4 @@
-package com.my.version.feature.evaluate.record.model
+package com.my.version.feature.evaluate.record.state
 
 import com.my.version.core.domain.entity.MusicAudioFile
 

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/state/EvaluationRecordUiState.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/state/EvaluationRecordUiState.kt
@@ -6,5 +6,5 @@ data class EvaluationRecordUiState(
     val music: MusicAudioFile?= null,
     val songLyrics: Map<Long, String> = mapOf(),
     val currentTimeStamp: Long = 0L,
-    val isNextEnabled: Boolean = false,
+    val isNextEnabled: Boolean = true,
 )

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/select/EvaluationSelectScreen.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/select/EvaluationSelectScreen.kt
@@ -13,14 +13,18 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.my.version.core.designsystem.component.button.RectangleButton
 import com.my.version.core.designsystem.component.divider.BasicSpacer
 import com.my.version.core.designsystem.component.divider.TitleWithDivider
@@ -33,28 +37,40 @@ import com.my.version.core.designsystem.type.TempItem
 import com.my.version.core.designsystem.type.VerticalItemType
 import com.my.version.core.designsystem.type.tempList1
 import com.my.version.feature.evaluate.R
+import com.my.version.feature.evaluate.select.state.EvaluationSelectUiState
 
 @Composable
 fun EvaluationSelectRoute(
+    navigateUp: () -> Unit,
+    navigateToRecord:() -> Unit,
     modifier: Modifier = Modifier,
     viewModel: EvaluationSelectViewModel = hiltViewModel()
 ) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle(lifecycleOwner = lifecycleOwner)
+
     EvaluationSelectScreen(
         modifier = modifier,
-        coverList = tempList1
+        uiState = uiState,
+        onItemClicked = {},
+        onNextClicked = navigateToRecord,
+        onBackPressed = navigateUp
     )
 }
 
 @Composable
 private fun EvaluationSelectScreen(
-    modifier: Modifier = Modifier,
-    coverList: List<TempItem> = emptyList()
+    onNextClicked: () -> Unit,
+    onItemClicked: () -> Unit,
+    onBackPressed: () -> Unit,
+    uiState: EvaluationSelectUiState,
+    modifier: Modifier = Modifier
 ) {
     Column(
         modifier = modifier.fillMaxSize()
     ) {
         NavigateUpTopAppBar(
-            onNavigateUp = { /*TODO*/ },
+            onNavigateUp = onBackPressed,
             title = stringResource(id = R.string.evaluation_topbar_selection)
         )
 
@@ -72,17 +88,16 @@ private fun EvaluationSelectScreen(
                 .weight(1f),
             contentPadding = PaddingValues(vertical = 10.dp)
         ) {
-            items(coverList) { cover ->
-
+            itemsIndexed(uiState.musicList) { index, cover ->
                 MyVersionVerticalItem(
                     itemType = VerticalItemType.COVER,
                     iconColor = Black,
                     onClick = {
                     },
                     title = cover.title,
-                    subTitle = cover.body
+                    subTitle = cover.createdDate
                 )
-                if (coverList.last() != cover) {
+                if (index < uiState.musicList.lastIndex) {
                     BasicSpacer(height = 16.dp)
                 }
             }
@@ -93,11 +108,12 @@ private fun EvaluationSelectScreen(
             contentAlignment = Alignment.TopCenter
         ) {
             RectangleButton(
-                isEnabled = false,
+                isEnabled = true,
                 text = "Next",
                 textStyle = MaterialTheme.typography.titleMedium,
                 innerPadding = 20,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
+                onClick = onNextClicked
             )
         }
     }
@@ -109,7 +125,10 @@ private fun EvaluationSelectScreenPreview() {
     MyVersionTheme {
         Box(modifier = Modifier.background(color = MyVersionBackground)) {
             EvaluationSelectScreen(
-                coverList = tempList1
+                uiState = EvaluationSelectUiState(),
+                onBackPressed = {},
+                onNextClicked = {},
+                onItemClicked = {}
             )
         }
     }

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/select/EvaluationSelectScreen.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/select/EvaluationSelectScreen.kt
@@ -1,18 +1,14 @@
 package com.my.version.feature.evaluate.select
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -33,9 +29,7 @@ import com.my.version.core.designsystem.component.topappbar.NavigateUpTopAppBar
 import com.my.version.core.designsystem.theme.Black
 import com.my.version.core.designsystem.theme.MyVersionBackground
 import com.my.version.core.designsystem.theme.MyVersionTheme
-import com.my.version.core.designsystem.type.TempItem
 import com.my.version.core.designsystem.type.VerticalItemType
-import com.my.version.core.designsystem.type.tempList1
 import com.my.version.feature.evaluate.R
 import com.my.version.feature.evaluate.select.state.EvaluationSelectUiState
 

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/select/EvaluationSelectViewModel.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/select/EvaluationSelectViewModel.kt
@@ -1,10 +1,28 @@
 package com.my.version.feature.evaluate.select
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.my.version.feature.evaluate.select.state.EvaluationSelectUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+@HiltViewModel
 class EvaluationSelectViewModel @Inject constructor(
 
 ): ViewModel() {
+    private var _uiState = MutableStateFlow(EvaluationSelectUiState())
+    val uiState = _uiState.asStateFlow()
+
+    fun updateSelectedIndex(selectedIndex: Int) = viewModelScope.launch {
+        _uiState.update {
+            _uiState.value.copy(
+                selected = selectedIndex
+            )
+        }
+    }
 
 }

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/select/navigation/EvaluationSelectNavigation.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/select/navigation/EvaluationSelectNavigation.kt
@@ -13,11 +13,15 @@ import kotlinx.serialization.Serializable
 fun NavController.navigateToEvaluationSelect(navOptions: NavOptions? = null) = navigate(EvaluationSelect, navOptions)
 
 fun NavGraphBuilder.evaluationSelectScreen(
-    modifier: Modifier
+    modifier: Modifier,
+    navigateUp: () -> Unit,
+    navigateToRecord: () -> Unit
 ) {
     composable<EvaluationSelect>{
         EvaluationSelectRoute(
-            modifier = modifier
+            modifier = modifier,
+            navigateUp = navigateUp,
+            navigateToRecord = navigateToRecord
         )
     }
 }

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/select/navigation/EvaluationSelectNavigation.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/select/navigation/EvaluationSelectNavigation.kt
@@ -7,7 +7,6 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.my.version.core.common.navigation.Route
 import com.my.version.feature.evaluate.select.EvaluationSelectRoute
-import com.my.version.feature.evaluate.main.navigation.Evaluation
 import kotlinx.serialization.Serializable
 
 fun NavController.navigateToEvaluationSelect(navOptions: NavOptions? = null) = navigate(EvaluationSelect, navOptions)

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/select/state/EvaluationSelectUiState.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/select/state/EvaluationSelectUiState.kt
@@ -1,0 +1,8 @@
+package com.my.version.feature.evaluate.select.state
+
+import com.my.version.core.domain.entity.CoverAudioFile
+
+data class EvaluationSelectUiState(
+    val selected: Int = -1,
+    val musicList: List<CoverAudioFile> = emptyList()
+)

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/EvaluationUploadSideEffect.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/EvaluationUploadSideEffect.kt
@@ -1,0 +1,7 @@
+package com.my.version.feature.evaluate.upload
+
+import androidx.annotation.StringRes
+
+sealed class EvaluationUploadSideEffect {
+    data object CompleteSeekTo : EvaluationUploadSideEffect()
+}

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/EvaluationUploadSideEffect.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/EvaluationUploadSideEffect.kt
@@ -1,7 +1,5 @@
 package com.my.version.feature.evaluate.upload
 
-import androidx.annotation.StringRes
-
 sealed class EvaluationUploadSideEffect {
     data object CompleteSeekTo : EvaluationUploadSideEffect()
 }

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/EvaluationUploadViewModel.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/EvaluationUploadViewModel.kt
@@ -1,10 +1,14 @@
 package com.my.version.feature.evaluate.upload
 
 import androidx.lifecycle.ViewModel
+import com.my.version.core.common.media.MyVersionMediaPlayer
 import javax.inject.Inject
 
 class EvaluationUploadViewModel @Inject constructor(
 
 ): ViewModel() {
+
+    private var mediaPlayer = MyVersionMediaPlayer()
+
 
 }

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/EvaluationUploadViewModel.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/EvaluationUploadViewModel.kt
@@ -1,14 +1,75 @@
 package com.my.version.feature.evaluate.upload
 
+import android.media.MediaPlayer
 import androidx.lifecycle.ViewModel
-import com.my.version.core.common.media.MyVersionMediaPlayer
+import androidx.lifecycle.viewModelScope
+import com.my.version.feature.evaluate.upload.state.EvaluationUploadUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+@HiltViewModel
 class EvaluationUploadViewModel @Inject constructor(
 
-): ViewModel() {
+) : ViewModel() {
+    private var _uiState = MutableStateFlow(EvaluationUploadUiState())
+    val uiState = _uiState.asStateFlow()
 
-    private var mediaPlayer = MyVersionMediaPlayer()
+    private var mediaPlayer: MediaPlayer? = null
 
+    fun initUiState(
+        filePath: String,
+        songLyrics: Map<Long, String>
+    ) {
+        _uiState.update { currentState ->
+            currentState.copy(
+                filePath = filePath,
+                songLyrics = songLyrics
+            )
+        }
+        prepareAudio()
+    }
 
+    private fun prepareAudio() = viewModelScope.launch(Dispatchers.Main){
+        try {
+            mediaPlayer = MediaPlayer().apply {
+                setDataSource(uiState.value.filePath)
+                prepare()
+                setOnPreparedListener {
+                    _uiState.update { currentState ->
+                        currentState.copy(
+                            fileLength = it.duration
+                        )
+                    }
+                }
+                setOnCompletionListener {
+                    reset()
+                }
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    fun playAudio() = viewModelScope.launch(Dispatchers.Main){
+        mediaPlayer?.run {
+            if(this.isPlaying) {
+                this.pause()
+            } else {
+                this.start()
+            }
+        }
+    }
+
+    fun stopAudio() = viewModelScope.launch(Dispatchers.Main){
+        mediaPlayer?.run {
+            this.stop()
+            this.release()
+        }
+        mediaPlayer = null
+    }
 }

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/EvaluationUploadViewModel.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/EvaluationUploadViewModel.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/EvalutaionUploadScreen.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/EvalutaionUploadScreen.kt
@@ -13,8 +13,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
-import androidx.compose.material3.SliderDefaults
-import androidx.compose.material3.SliderState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -40,7 +38,6 @@ import com.my.version.core.designsystem.theme.MyVersionTheme
 import com.my.version.feature.evaluate.R
 import com.my.version.feature.evaluate.component.LyricView
 import com.my.version.feature.evaluate.upload.state.EvaluationUploadUiState
-import timber.log.Timber
 import com.my.version.core.designsystem.R as DesignSystemR
 
 @Composable

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/EvalutaionUploadScreen.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/EvalutaionUploadScreen.kt
@@ -1,6 +1,7 @@
 package com.my.version.feature.evaluate.upload
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,9 +13,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.SliderState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -36,6 +40,7 @@ import com.my.version.core.designsystem.theme.MyVersionTheme
 import com.my.version.feature.evaluate.R
 import com.my.version.feature.evaluate.component.LyricView
 import com.my.version.feature.evaluate.upload.state.EvaluationUploadUiState
+import timber.log.Timber
 import com.my.version.core.designsystem.R as DesignSystemR
 
 @Composable
@@ -51,20 +56,23 @@ fun EvaluationUploadRoute(
     LaunchedEffect(true) {
         //viewModel.updateFilePath(filePath)
         viewModel.initUiState(
-            filePath = "/storage/emulated/0/Android/data/com.my.version/files/Recordings/240919161545.mp4",
-            //filePath = "/storage/emulated/0/Android/data/com.my.version/files/Recordings/240918190412.mp4",
+            filePath = "/storage/emulated/0/Android/data/com.my.version/files/Music/Ditto_NewJeans.mp3",
             songLyrics = LrcConverter.convertToLyricMap(context.resources.openRawResource(R.raw.ditto))
         )
+    }
+
+    LaunchedEffect(uiState.isPlaying) {
+        if(uiState.isPlaying) {
+            viewModel.updateProgress()
+        }
     }
 
     EvaluationUploadScreen(
         onClickClose = viewModel::stopAudio,
         onClickBack = {},
         onClickUpload = {},
-        onClickPlay = {
-            viewModel.playAudio()
-        },
-        onChangeSlider = {},
+        onClickPlay = viewModel::playAudio,
+        onChangeSlider = viewModel::changeSlider,
         uiState = uiState,
         modifier = modifier
     )
@@ -83,6 +91,7 @@ private fun EvaluationUploadScreen(
     val commonModifier = Modifier
         .fillMaxWidth()
         .padding(horizontal = 20.dp)
+    val interactionSource = remember { MutableInteractionSource() }
 
     Column(
         modifier = modifier.fillMaxSize()
@@ -109,9 +118,10 @@ private fun EvaluationUploadScreen(
         )
 
         Slider(
-            value = 0f,
+            value = uiState.progress,
             valueRange = 0f .. 1f,
             onValueChange = onChangeSlider,
+            interactionSource = interactionSource,
             modifier = commonModifier
                 .padding(vertical = 30.dp)
                 .height(7.dp),

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/EvalutaionUploadScreen.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/EvalutaionUploadScreen.kt
@@ -35,13 +35,17 @@ import com.my.version.core.designsystem.theme.MyVersionBackground
 import com.my.version.core.designsystem.theme.MyVersionTheme
 import com.my.version.core.designsystem.theme.White
 import com.my.version.feature.evaluate.R
+import timber.log.Timber
 import com.my.version.core.designsystem.R as DesignSystemR
 
 @Composable
 fun EvaluationUploadRoute(
+    filePath: String,
     modifier: Modifier = Modifier,
     viewModel: EvaluationUploadViewModel = hiltViewModel()
 ) {
+    Timber.tag("RecordingTest").d("filePath: $filePath")
+
     EvaluationUploadScreen(
         modifier = modifier
     )

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/EvalutaionUploadScreen.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/EvalutaionUploadScreen.kt
@@ -4,27 +4,27 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import androidx.compose.material3.Slider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.my.version.core.common.media.LrcConverter
 import com.my.version.core.designsystem.component.button.MyVersionBasicIconButton
 import com.my.version.core.designsystem.component.button.RectangleButton
 import com.my.version.core.designsystem.component.divider.MyVersionHorizontalDivider
@@ -33,9 +33,9 @@ import com.my.version.core.designsystem.component.topappbar.NavigateUpTopAppBar
 import com.my.version.core.designsystem.theme.Grey200
 import com.my.version.core.designsystem.theme.MyVersionBackground
 import com.my.version.core.designsystem.theme.MyVersionTheme
-import com.my.version.core.designsystem.theme.White
 import com.my.version.feature.evaluate.R
-import timber.log.Timber
+import com.my.version.feature.evaluate.component.LyricView
+import com.my.version.feature.evaluate.upload.state.EvaluationUploadUiState
 import com.my.version.core.designsystem.R as DesignSystemR
 
 @Composable
@@ -44,17 +44,41 @@ fun EvaluationUploadRoute(
     modifier: Modifier = Modifier,
     viewModel: EvaluationUploadViewModel = hiltViewModel()
 ) {
-    Timber.tag("RecordingTest").d("filePath: $filePath")
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle(lifecycleOwner)
+
+    LaunchedEffect(true) {
+        //viewModel.updateFilePath(filePath)
+        viewModel.initUiState(
+            filePath = "/storage/emulated/0/Android/data/com.my.version/files/Recordings/240919161545.mp4",
+            //filePath = "/storage/emulated/0/Android/data/com.my.version/files/Recordings/240918190412.mp4",
+            songLyrics = LrcConverter.convertToLyricMap(context.resources.openRawResource(R.raw.ditto))
+        )
+    }
 
     EvaluationUploadScreen(
+        onClickClose = viewModel::stopAudio,
+        onClickBack = {},
+        onClickUpload = {},
+        onClickPlay = {
+            viewModel.playAudio()
+        },
+        onChangeSlider = {},
+        uiState = uiState,
         modifier = modifier
     )
 }
 
 @Composable
 private fun EvaluationUploadScreen(
+    onClickBack: () -> Unit,
+    onClickPlay: () -> Unit,
+    onClickClose: () -> Unit,
+    onClickUpload: () -> Unit,
+    onChangeSlider: (Float) -> Unit,
+    uiState: EvaluationUploadUiState,
     modifier: Modifier = Modifier,
-    lyrics: List<String> = emptyList()
 ) {
     val commonModifier = Modifier
         .fillMaxWidth()
@@ -64,7 +88,7 @@ private fun EvaluationUploadScreen(
         modifier = modifier.fillMaxSize()
     ) {
         NavigateUpTopAppBar(
-            onNavigateUp = { /*TODO*/ },
+            onNavigateUp = onClickBack,
             title = stringResource(id = R.string.evaluation_topbar_upload)
         )
 
@@ -74,33 +98,23 @@ private fun EvaluationUploadScreen(
             modifier = commonModifier
         )
 
-        LazyColumn(
-            modifier = commonModifier
-                .height(450.dp),
-            contentPadding = PaddingValues(20.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            items(lyrics) { line ->
-                Text(
-                    text = line,
-                    color = White,
-                    style = MaterialTheme.typography.titleMedium
-                )
-
-                Spacer(modifier = Modifier.height(6.dp))
-            }
-        }
+        LyricView(
+            lyrics = uiState.songLyrics,
+            timeStamp = uiState.currentTimeStamp,
+            modifier = commonModifier.height(450.dp)
+        )
 
         MyVersionHorizontalDivider(
             modifier = commonModifier
         )
 
-        LinearProgressIndicator(
-            progress = { 0.3f },
+        Slider(
+            value = 0f,
+            valueRange = 0f .. 1f,
+            onValueChange = onChangeSlider,
             modifier = commonModifier
                 .padding(vertical = 30.dp)
                 .height(7.dp),
-            strokeCap = StrokeCap.Round
         )
 
         Row(
@@ -110,13 +124,13 @@ private fun EvaluationUploadScreen(
         ) {
             MyVersionBasicIconButton(
                 icon = DesignSystemR.drawable.ic_close,
-                onClick = { /*TODO*/ },
+                onClick = onClickClose,
                 color = Grey200
             )
 
             MyVersionBasicIconButton(
                 icon = DesignSystemR.drawable.ic_play,
-                onClick = { /*TODO*/ },
+                onClick = onClickPlay,
                 color = Grey200,
                 modifier = Modifier.size(32.dp)
             )
@@ -131,6 +145,7 @@ private fun EvaluationUploadScreen(
                 text = stringResource(id = DesignSystemR.string.btn_upload_capital),
                 textStyle = MaterialTheme.typography.titleMedium,
                 innerPadding = 20,
+                onClick = onClickUpload,
                 modifier = Modifier.fillMaxWidth()
             )
         }
@@ -142,14 +157,13 @@ private fun EvaluationUploadScreen(
 private fun EvaluationRecordScreenPreview() {
     MyVersionTheme {
         EvaluationUploadScreen(
+            onClickClose = {},
+            onClickBack = {},
+            onClickUpload = {},
+            onClickPlay = {},
+            onChangeSlider = {},
             modifier = Modifier.background(MyVersionBackground),
-            lyrics = listOf(
-                "sdasdasdasd",
-                "asdsadasdsad",
-                "fsdabfahdfadsf",
-                "dafsdfafadf",
-                "safdsfsgfsdg"
-            )
+            uiState = EvaluationUploadUiState()
         )
     }
 }

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/navigation/EvaluationUploadNavigation.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/navigation/EvaluationUploadNavigation.kt
@@ -1,25 +1,31 @@
 package com.my.version.feature.evaluate.upload.navigation
 
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Path
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
 import com.my.version.core.common.navigation.Route
 import com.my.version.feature.evaluate.upload.EvaluationUploadRoute
 import kotlinx.serialization.Serializable
 
-fun NavController.navigateToEvaluationUpload(navOptions: NavOptions? = null) = navigate(EvaluationUpload, navOptions)
+fun NavController.navigateToEvaluationUpload(navOptions: NavOptions? = null, filePath: String) = navigate(EvaluationUpload(filePath), navOptions)
 
 fun NavGraphBuilder.evaluationUploadScreen(
     modifier: Modifier
 ) {
-    composable<EvaluationUpload>{
+    composable<EvaluationUpload>{ backStackEntry ->
+        val filePath = backStackEntry.toRoute<EvaluationUpload>().filePath
         EvaluationUploadRoute(
-            modifier = modifier
+            modifier = modifier,
+            filePath = filePath
         )
     }
 }
 
 @Serializable
-data object EvaluationUpload: Route
+data class EvaluationUpload(
+    val filePath: String = ""
+): Route

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/navigation/EvaluationUploadNavigation.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/navigation/EvaluationUploadNavigation.kt
@@ -1,7 +1,6 @@
 package com.my.version.feature.evaluate.upload.navigation
 
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Path
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/state/EvaluationUploadUiState.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/state/EvaluationUploadUiState.kt
@@ -1,0 +1,11 @@
+package com.my.version.feature.evaluate.upload.state
+
+import com.my.version.core.domain.entity.MusicAudioFile
+
+data class EvaluationUploadUiState(
+    val filePath: String = "",
+    val fileLength: Int = 0,
+    val music: MusicAudioFile? = null,
+    val songLyrics: Map<Long, String> = mapOf(),
+    val currentTimeStamp: Long = 0L
+)

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/state/EvaluationUploadUiState.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/state/EvaluationUploadUiState.kt
@@ -7,5 +7,7 @@ data class EvaluationUploadUiState(
     val fileLength: Int = 0,
     val music: MusicAudioFile? = null,
     val songLyrics: Map<Long, String> = mapOf(),
-    val currentTimeStamp: Long = 0L
+    val currentTimeStamp: Long = 0L,
+    val isPlaying: Boolean = false,
+    val progress: Float = 0f
 )

--- a/feature/main/src/main/java/com/my/version/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/my/version/feature/main/MainScreen.kt
@@ -32,6 +32,7 @@ import com.my.version.feature.cover.upload.navigation.coverUploadScreen
 import com.my.version.feature.cover.upload.navigation.navigateToCoverUpload
 import com.my.version.feature.evaluate.main.navigation.evaluationScreen
 import com.my.version.feature.evaluate.record.navigation.evaluationRecordScreen
+import com.my.version.feature.evaluate.record.navigation.navigateToEvaluationRecord
 import com.my.version.feature.evaluate.select.navigation.evaluationSelectScreen
 import com.my.version.feature.evaluate.select.navigation.navigateToEvaluationSelect
 import com.my.version.feature.evaluate.upload.navigation.evaluationUploadScreen
@@ -104,7 +105,9 @@ private fun MyVersionNavHost(
             navigateToResult = {}
         )
         evaluationSelectScreen(
-            modifier = noBottomBarModifier
+            modifier = noBottomBarModifier,
+            navigateUp = navController::navigateUp,
+            navigateToRecord = navController::navigateToEvaluationRecord
         )
         evaluationRecordScreen(
             modifier = noBottomBarModifier

--- a/feature/main/src/main/java/com/my/version/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/my/version/feature/main/MainScreen.kt
@@ -19,6 +19,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import com.my.version.core.common.navigation.Route
 import com.my.version.core.designsystem.theme.Grey400
+import com.my.version.core.designsystem.theme.MyVersionBackground
 import com.my.version.core.designsystem.theme.MyVersionMain
 import com.my.version.core.designsystem.theme.White
 import com.my.version.feature.auth.signin.navigation.signInScreen
@@ -131,7 +132,7 @@ private fun MainBottomBar(
         exit = fadeOut()
     ) {
         NavigationBar(
-            containerColor = MyVersionMain
+            containerColor = MyVersionBackground
         ) {
             tabs.forEach { itemType ->
                 NavigationBarItem(
@@ -158,7 +159,7 @@ private fun MainBottomBar(
                             selectedTextColor = White,
                             unselectedIconColor = Grey400,
                             unselectedTextColor = Grey400,
-                            indicatorColor = MyVersionMain
+                            indicatorColor = MyVersionBackground
                         )
                 )
             }

--- a/feature/main/src/main/java/com/my/version/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/my/version/feature/main/MainScreen.kt
@@ -33,6 +33,7 @@ import com.my.version.feature.cover.upload.navigation.navigateToCoverUpload
 import com.my.version.feature.evaluate.main.navigation.evaluationScreen
 import com.my.version.feature.evaluate.record.navigation.evaluationRecordScreen
 import com.my.version.feature.evaluate.select.navigation.evaluationSelectScreen
+import com.my.version.feature.evaluate.select.navigation.navigateToEvaluationSelect
 import com.my.version.feature.evaluate.upload.navigation.evaluationUploadScreen
 import com.my.version.feature.home.navigation.homeScreen
 import com.my.version.feature.home.navigation.navigateToHome
@@ -98,7 +99,9 @@ private fun MyVersionNavHost(
             onUploadComplete = { navController.popBackStack(Cover, inclusive = false) }
         )
         evaluationScreen(
-            modifier = modifier
+            modifier = modifier,
+            navigateToSelect = navController::navigateToEvaluationSelect,
+            navigateToResult = {}
         )
         evaluationSelectScreen(
             modifier = noBottomBarModifier

--- a/feature/main/src/main/java/com/my/version/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/my/version/feature/main/MainScreen.kt
@@ -36,6 +36,7 @@ import com.my.version.feature.evaluate.record.navigation.navigateToEvaluationRec
 import com.my.version.feature.evaluate.select.navigation.evaluationSelectScreen
 import com.my.version.feature.evaluate.select.navigation.navigateToEvaluationSelect
 import com.my.version.feature.evaluate.upload.navigation.evaluationUploadScreen
+import com.my.version.feature.evaluate.upload.navigation.navigateToEvaluationUpload
 import com.my.version.feature.home.navigation.homeScreen
 import com.my.version.feature.home.navigation.navigateToHome
 import com.terning.core.util.NoRippleInteractionSource
@@ -110,6 +111,10 @@ private fun MyVersionNavHost(
             navigateToRecord = navController::navigateToEvaluationRecord
         )
         evaluationRecordScreen(
+            navigateUp = navController::navigateUp,
+            navigateToEvaluationUpload = { filePath ->
+                navController.navigateToEvaluationUpload(filePath = filePath)
+            },
             modifier = noBottomBarModifier
         )
         evaluationUploadScreen(


### PR DESCRIPTION
- closed #25 

## 🫡 Work Done
- 음악 및 녹음 동시 진행 기능
  - MediaPlayer와 MediaRecorder 사용
- 가사 표시
  - 노래 시간에 맞춘 가사 색상 표시 
- 녹음본 탐색 기능
 
## 📌 Note
- 미완성, 추후에 더 다듬을 예정.
- 현재 디자인 변경으로 인해 일단 머지
- 서버 API 미완성으로 인해 임시 파일을 참조함
- 임시 파일들은 올라오지 않은 상황임으로 현재 코드를 따로 클론할 경우 오류 발생

