### PR TITLE
[FiX/#50] 커버 업로드 화면 오디오

### DIFF
--- a/core/designsystem/src/main/java/com/my/version/core/designsystem/component/dialog/MyVersionBasicDialog.kt
+++ b/core/designsystem/src/main/java/com/my/version/core/designsystem/component/dialog/MyVersionBasicDialog.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.my.version.core.designsystem.R
 import com.my.version.core.designsystem.theme.MyVersionBackground
 import com.my.version.core.designsystem.theme.MyVersionTheme
@@ -24,10 +25,12 @@ import com.my.version.core.designsystem.theme.White
 fun MyVersionBasicDialog(
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
-    content: @Composable () -> Unit,
+    properties: DialogProperties = DialogProperties(),
+    content: @Composable () -> Unit
 ) {
     Dialog(
         onDismissRequest = onDismiss,
+        properties = properties
     ) {
         Column(
             modifier = modifier

--- a/feature/cover/src/main/java/com/my/version/feature/cover/upload/CoverUploadScreen.kt
+++ b/feature/cover/src/main/java/com/my/version/feature/cover/upload/CoverUploadScreen.kt
@@ -42,7 +42,6 @@ import com.my.version.feature.cover.record.RecordDialog
 import com.my.version.feature.cover.upload.component.ConfirmDialog
 import com.my.version.feature.cover.upload.component.CoverUploadIconButton
 import com.my.version.feature.cover.upload.component.uploadResultLauncher
-import timber.log.Timber
 import java.io.File
 import com.my.version.core.designsystem.R as DesignSystemR
 
@@ -61,7 +60,6 @@ fun CoverUploadRoute(
         onResultOk = { dataUri ->
             val file = File(dataUri.toString())
             viewModel.addRecordFile(file.absolutePath)
-            Timber.tag("Upload").d(file.absolutePath)
         }
     )
 
@@ -91,7 +89,6 @@ fun CoverUploadRoute(
         onPlayButtonClicked = viewModel::playRecordFile,
         onUploadComplete = {
             viewModel.updateUploadDialogVisibility(true)
-            //viewModel.clearRecordFiles()
         }
     )
 
@@ -106,7 +103,10 @@ fun CoverUploadRoute(
 
     DisposableEffect(true) {
         onDispose {
-            viewModel.clearRecordFiles()
+            with(viewModel) {
+                clearRecordFiles()
+                stopRecordFile()
+            }
         }
     }
 }

--- a/feature/cover/src/main/java/com/my/version/feature/cover/upload/component/ConfirmDialog.kt
+++ b/feature/cover/src/main/java/com/my/version/feature/cover/upload/component/ConfirmDialog.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
 import com.my.version.core.common.state.UiState
 import com.my.version.core.designsystem.component.button.RectangleButton
 import com.my.version.core.designsystem.component.dialog.MyVersionBasicDialog
@@ -35,36 +36,56 @@ fun ConfirmDialog(
     visibility: Boolean = false
 ) {
     if (visibility) {
-        MyVersionBasicDialog(
-            onDismiss = onDismissRequest,
-            modifier = modifier.wrapContentHeight()
-        ) {
-            when (dialogState.loadState) {
-                is UiState.Empty -> {
+
+        when (dialogState.loadState) {
+            is UiState.Empty -> {
+                MyVersionBasicDialog(
+                    onDismiss = onDismissRequest,
+                    modifier = modifier.wrapContentHeight(),
+                ) {
                     ConfirmView(
                         text = text,
                         onDismissRequest = onDismissRequest,
                         onConfirmRequest = onUploadRequest
                     )
                 }
+            }
 
-                is UiState.Loading -> {
+            is UiState.Loading -> {
+                MyVersionBasicDialog(
+                    onDismiss = {},
+                    modifier = modifier.wrapContentHeight(),
+                    properties = DialogProperties(
+                        dismissOnBackPress = false,
+                        dismissOnClickOutside = false
+                    )
+                ) {
                     UploadProcessView(
                         titleTextRes = R.string.cover_dialog_uploading,
                         buttonTextRes = R.string.cover_dialog_button_uploading,
                         buttonEnabled = false
                     )
                 }
+            }
 
-                is UiState.Failure -> {
+            is UiState.Failure -> {
+                MyVersionBasicDialog(
+                    onDismiss = onDismissRequest,
+                    modifier = modifier.wrapContentHeight(),
+                ) {
                     UploadProcessView(
                         titleTextRes = R.string.cover_dialog_upload_error,
                         buttonTextRes = R.string.cover_dialog_button_retry,
                         onClick = onUploadRequest
                     )
                 }
+            }
 
-                is UiState.Success -> {
+            is UiState.Success -> {
+                MyVersionBasicDialog(
+                    onDismiss = onConfirmRequest,
+                    modifier = modifier.wrapContentHeight(),
+                ) {
                     UploadProcessView(
                         titleTextRes = R.string.cover_dialog_upload_complete,
                         buttonTextRes = R.string.cover_dialog_button_complete,
@@ -75,6 +96,7 @@ fun ConfirmDialog(
         }
     }
 }
+
 
 @Composable
 private fun ConfirmView(


### PR DESCRIPTION
- closed #50 

## 🫡 Work Done
- 화면 이탈 시 오디오 자동 종료 구현
- 업로드 상태에 따른 다이얼로그 dismiss 변경
 
## 📌 Note
