### PR TITLE
[FEAT/#58] 가사 api 연동

### DIFF
--- a/app/src/main/java/com/my/version/di/RepositoryModule.kt
+++ b/app/src/main/java/com/my/version/di/RepositoryModule.kt
@@ -5,6 +5,7 @@ import com.my.version.core.data.repositoryimpl.CoverRepositoryImpl
 import com.my.version.core.data.repositoryimpl.CoverUploadRepositoryImpl
 import com.my.version.core.data.repositoryimpl.EvaluationRepositoryImpl
 import com.my.version.core.data.repositoryimpl.EvaluationUploadRepositoryImpl
+import com.my.version.core.data.repositoryimpl.LyricRepositoryImpl
 import com.my.version.core.data.repositoryimpl.MusicRepositoryImpl
 import com.my.version.core.data.repositoryimpl.RecordLocalRepositoryImpl
 import com.my.version.core.data.repositoryimpl.RecordRepositoryImpl
@@ -14,6 +15,7 @@ import com.my.version.core.domain.repository.CoverRepository
 import com.my.version.core.domain.repository.CoverUploadRepository
 import com.my.version.core.domain.repository.EvaluationRepository
 import com.my.version.core.domain.repository.EvaluationUploadRepository
+import com.my.version.core.domain.repository.LyricRepository
 import com.my.version.core.domain.repository.MusicRepository
 import com.my.version.core.domain.repository.RecordLocalRepository
 import com.my.version.core.domain.repository.RecordRepository
@@ -82,4 +84,11 @@ abstract class RepositoryModule {
     abstract fun bindEvaluationUploadepository(
         evaluationUploadRepositoryImpl: EvaluationUploadRepositoryImpl
     ): EvaluationUploadRepository
+
+
+    @Binds
+    @Singleton
+    abstract fun bindLyricRepository(
+        lyricRepositoryImpl: LyricRepositoryImpl
+    ): LyricRepository
 }

--- a/core/common/src/main/java/com/my/version/core/common/extension/DownloadManagerExt.kt
+++ b/core/common/src/main/java/com/my/version/core/common/extension/DownloadManagerExt.kt
@@ -4,16 +4,15 @@ import android.app.DownloadManager
 import android.net.Uri
 import android.os.Environment
 import androidx.compose.runtime.compositionLocalOf
+import timber.log.Timber
 import java.io.File
 
 fun DownloadManager.download(
-    downloadUri: Uri,
-    outputPath: String,
-    notificationTitle: String
-) {
+    downloadUri: Uri, outputPath: String, notificationTitle: String
+) = try {
     val downloadPath =
         Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).absolutePath + "/$outputPath"
-
+    Timber.tag("DownloadManager").d("download: $downloadUri, outputPath: $outputPath")
     val destinationUri = Uri.fromFile(File(downloadPath))
 
     val request = DownloadManager.Request(downloadUri).apply {
@@ -22,6 +21,8 @@ fun DownloadManager.download(
         setAllowedOverMetered(true)
     }
     enqueue(request)
+} catch (e: Exception) {
+    e.printStackTrace()
 }
 
 

--- a/core/common/src/main/java/com/my/version/core/common/media/LrcConverter.kt
+++ b/core/common/src/main/java/com/my/version/core/common/media/LrcConverter.kt
@@ -1,18 +1,19 @@
 package com.my.version.core.common.media
 
+import timber.log.Timber
 import java.io.BufferedReader
 import java.io.InputStream
 import java.io.InputStreamReader
 
 object LrcConverter {
-    fun convertToLyricMap( inputStream: InputStream): LinkedHashMap<Long, String> =
+    fun convertToLyricMap(inputStream: InputStream): LinkedHashMap<Long, String> =
         linkedMapOf<Long, String>().apply {
             val reader = BufferedReader(InputStreamReader(inputStream))
             reader.forEachLine { line ->
                 val splitStrings = line.split("]")
                 val timeInMillis = convertToMillis(splitStrings[0].removePrefix("["))
                 val lyricString = splitStrings[1]
-
+                Timber.tag("Lyrics").d("timeInMillis: $timeInMillis, lyricString: $lyricString")
                 put(timeInMillis, lyricString)
             }
         }
@@ -28,7 +29,8 @@ object LrcConverter {
         val milliseconds = if (parts.size > 3) parts[3].toInt() else 0
 
         // 각 값을 밀리초로 변환 후 합산
-        val totalMillis = (hours * 3600000L) + (minutes * 60000L) + (seconds * 1000L) + milliseconds*10L
+        val totalMillis =
+            (hours * 3600000L) + (minutes * 60000L) + (seconds * 1000L) + milliseconds * 10L
         return totalMillis
     }
 }

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -15,15 +15,23 @@ android {
 
     defaultConfig {
         consumerProguardFiles("consumer-rules.pro")
+
+        buildConfigField(
+            "String",
+            "BASE_URL",
+            properties.getProperty("base.url")
+        )
+
+        buildConfigField(
+            "String",
+            "LYRIC_URL",
+            properties.getProperty("lyric.stream.url")
+        )
     }
 
     buildTypes {
         debug {
-            buildConfigField(
-                "String",
-                "BASE_URL",
-                properties.getProperty("base.url")
-            )
+
         }
 
         release {

--- a/core/data/src/main/java/com/my/version/core/data/datasource/di/DataSourceModule.kt
+++ b/core/data/src/main/java/com/my/version/core/data/datasource/di/DataSourceModule.kt
@@ -5,6 +5,7 @@ import com.my.version.core.data.datasource.local.ScopedStorageDataSource
 import com.my.version.core.data.datasource.remote.AuthDataSource
 import com.my.version.core.data.datasource.remote.CoverDataSource
 import com.my.version.core.data.datasource.remote.EvaluationDataSource
+import com.my.version.core.data.datasource.remote.LyricDataSource
 import com.my.version.core.data.datasource.remote.MusicDataSource
 import com.my.version.core.data.datasourceimpl.local.RecordDataSourceImpl
 import com.my.version.core.data.datasourceimpl.local.ScopedStorageDataSourceImpl
@@ -64,5 +65,5 @@ abstract class DataSourceModule {
     @Singleton
     abstract fun bindLyricDataSource(
         lyricDataSourceImpl: LyricDataSourceImpl
-    ): LyricDataSourceImpl
+    ): LyricDataSource
 }

--- a/core/data/src/main/java/com/my/version/core/data/datasource/di/DataSourceModule.kt
+++ b/core/data/src/main/java/com/my/version/core/data/datasource/di/DataSourceModule.kt
@@ -11,6 +11,7 @@ import com.my.version.core.data.datasourceimpl.local.ScopedStorageDataSourceImpl
 import com.my.version.core.data.datasourceimpl.remote.AuthDataSourceImpl
 import com.my.version.core.data.datasourceimpl.remote.CoverDataSourceImpl
 import com.my.version.core.data.datasourceimpl.remote.EvaluationDataSourceImpl
+import com.my.version.core.data.datasourceimpl.remote.LyricDataSourceImpl
 import com.my.version.core.data.datasourceimpl.remote.MusicDataSourceImpl
 import dagger.Binds
 import dagger.Module
@@ -57,4 +58,11 @@ abstract class DataSourceModule {
     abstract fun bindEvaluationDataSource(
         evaluationDataSourceImpl: EvaluationDataSourceImpl
     ): EvaluationDataSource
+
+
+    @Binds
+    @Singleton
+    abstract fun bindLyricDataSource(
+        lyricDataSourceImpl: LyricDataSourceImpl
+    ): LyricDataSourceImpl
 }

--- a/core/data/src/main/java/com/my/version/core/data/datasource/remote/LyricDataSource.kt
+++ b/core/data/src/main/java/com/my/version/core/data/datasource/remote/LyricDataSource.kt
@@ -1,0 +1,5 @@
+package com.my.version.core.data.datasource.remote
+
+interface LyricDataSource {
+    suspend fun fetchLyrics(fileName: String): LinkedHashMap<Long, String>
+}

--- a/core/data/src/main/java/com/my/version/core/data/datasourceimpl/remote/LyricDataSourceImpl.kt
+++ b/core/data/src/main/java/com/my/version/core/data/datasourceimpl/remote/LyricDataSourceImpl.kt
@@ -1,0 +1,30 @@
+package com.my.version.core.data.datasourceimpl.remote
+
+import com.my.version.core.common.media.LrcConverter
+import com.my.version.core.data.datasource.remote.LyricDataSource
+import com.my.version.core.data.service.LyricService
+import javax.inject.Inject
+
+class LyricDataSourceImpl @Inject constructor(
+    private val lyricService: LyricService
+) : LyricDataSource {
+    override suspend fun fetchLyrics(fileName: String): LinkedHashMap<Long, String> {
+        /*
+        val lyricList = mutableListOf<String>()
+        val responseBody = lyricService.getLyric(fileName)
+        responseBody.byteStream().use { inputStream ->
+            val reader = BufferedReader(InputStreamReader(inputStream))
+            var line: String?
+
+            while (reader.readLine().also { line = it } != null) {
+                lyricList.add(line.orEmpty())
+            }
+        }
+        return lyricList
+        */
+
+        val responseBody = lyricService.getLyric(fileName)
+        val lyricMap = LrcConverter.convertToLyricMap(responseBody.byteStream())
+        return lyricMap
+    }
+}

--- a/core/data/src/main/java/com/my/version/core/data/datasourceimpl/remote/LyricDataSourceImpl.kt
+++ b/core/data/src/main/java/com/my/version/core/data/datasourceimpl/remote/LyricDataSourceImpl.kt
@@ -1,8 +1,10 @@
 package com.my.version.core.data.datasourceimpl.remote
 
 import com.my.version.core.common.media.LrcConverter
+import com.my.version.core.data.BuildConfig.LYRIC_URL
 import com.my.version.core.data.datasource.remote.LyricDataSource
 import com.my.version.core.data.service.LyricService
+import timber.log.Timber
 import javax.inject.Inject
 
 class LyricDataSourceImpl @Inject constructor(
@@ -23,8 +25,10 @@ class LyricDataSourceImpl @Inject constructor(
         return lyricList
         */
 
+        Timber.tag("Lyrics").d("Lyric Invoked $LYRIC_URL$fileName")
         val responseBody = lyricService.getLyric(fileName)
         val lyricMap = LrcConverter.convertToLyricMap(responseBody.byteStream())
+
         return lyricMap
     }
 }

--- a/core/data/src/main/java/com/my/version/core/data/mapper/CoverAudioMapper.kt
+++ b/core/data/src/main/java/com/my/version/core/data/mapper/CoverAudioMapper.kt
@@ -20,6 +20,10 @@ fun CoverListResponse.toCoverAudio(): CoverAudio {
         createdDate = formattedDateString,
         audio = this.s3FileLocation.orEmpty(),
         artist = this.artist,
-        music = this.music
+        music = this.music,
+        dateString = this.createdDate,
+        fileName = FILE_FORMAT.format(this.music, this.userId, this.createdDate)
     )
 }
+
+private const val FILE_FORMAT = "%s-%s-%s.wav"

--- a/core/data/src/main/java/com/my/version/core/data/repositoryimpl/LyricRepositoryImpl.kt
+++ b/core/data/src/main/java/com/my/version/core/data/repositoryimpl/LyricRepositoryImpl.kt
@@ -1,0 +1,18 @@
+package com.my.version.core.data.repositoryimpl
+
+import com.my.version.core.data.datasource.remote.LyricDataSource
+import com.my.version.core.domain.repository.LyricRepository
+import javax.inject.Inject
+
+class LyricRepositoryImpl @Inject constructor(
+    private val lyricDataSource: LyricDataSource
+) : LyricRepository {
+    override suspend fun getLyrics(music: String, artist: String): LinkedHashMap<Long, String> {
+        val fileName = FILE_FORMAT.format(music, artist)
+        return lyricDataSource.fetchLyrics(fileName)
+    }
+
+    companion object {
+        private const val FILE_FORMAT = "%s-%s.lrc"
+    }
+}

--- a/core/data/src/main/java/com/my/version/core/data/repositoryimpl/LyricRepositoryImpl.kt
+++ b/core/data/src/main/java/com/my/version/core/data/repositoryimpl/LyricRepositoryImpl.kt
@@ -7,9 +7,12 @@ import javax.inject.Inject
 class LyricRepositoryImpl @Inject constructor(
     private val lyricDataSource: LyricDataSource
 ) : LyricRepository {
-    override suspend fun getLyrics(music: String, artist: String): LinkedHashMap<Long, String> {
+    override suspend fun getLyrics(
+        music: String,
+        artist: String
+    ): Result<LinkedHashMap<Long, String>> = runCatching {
         val fileName = FILE_FORMAT.format(music, artist)
-        return lyricDataSource.fetchLyrics(fileName)
+        lyricDataSource.fetchLyrics(fileName)
     }
 
     companion object {

--- a/core/data/src/main/java/com/my/version/core/data/repositoryimpl/LyricRepositoryImpl.kt
+++ b/core/data/src/main/java/com/my/version/core/data/repositoryimpl/LyricRepositoryImpl.kt
@@ -11,7 +11,8 @@ class LyricRepositoryImpl @Inject constructor(
         music: String,
         artist: String
     ): Result<LinkedHashMap<Long, String>> = runCatching {
-        val fileName = FILE_FORMAT.format(music, artist)
+        //TODO: val fileName = FILE_FORMAT.format(music, artist)
+        val fileName = FILE_FORMAT.format("Ditto", "NewJeans")
         lyricDataSource.fetchLyrics(fileName)
     }
 

--- a/core/data/src/main/java/com/my/version/core/data/service/LyricService.kt
+++ b/core/data/src/main/java/com/my/version/core/data/service/LyricService.kt
@@ -5,6 +5,6 @@ import retrofit2.http.GET
 import retrofit2.http.Path
 
 interface LyricService {
-    @GET("/{fileName}")
+    @GET("{fileName}")
     suspend fun getLyric(@Path("fileName") fileName: String): ResponseBody
 }

--- a/core/data/src/main/java/com/my/version/core/data/service/LyricService.kt
+++ b/core/data/src/main/java/com/my/version/core/data/service/LyricService.kt
@@ -1,0 +1,10 @@
+package com.my.version.core.data.service
+
+import okhttp3.ResponseBody
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface LyricService {
+    @GET("/{fileName}")
+    suspend fun getLyric(@Path("fileName") fileName: String): ResponseBody
+}

--- a/core/data/src/main/java/com/my/version/core/data/service/di/RetrofitModule.kt
+++ b/core/data/src/main/java/com/my/version/core/data/service/di/RetrofitModule.kt
@@ -1,7 +1,9 @@
 package com.my.version.core.data.service.di
 
 import com.my.version.core.data.BuildConfig.BASE_URL
+import com.my.version.core.data.BuildConfig.LYRIC_URL
 import com.my.version.core.data.service.di.qualifier.JWT
+import com.my.version.core.data.service.di.qualifier.LYRIC
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -42,6 +44,16 @@ object RetrofitModule {
             level = HttpLoggingInterceptor.Level.BODY
         }).build())
         .addConverterFactory(ScalarsConverterFactory.create())
+        .addConverterFactory(factory)
+        .build()
+
+    @Provides
+    @Singleton
+    @LYRIC
+    fun provideLyricRetrofit(
+        @JWT factory: Converter.Factory,
+    ): Retrofit = Retrofit.Builder()
+        .baseUrl(LYRIC_URL)
         .addConverterFactory(factory)
         .build()
 }

--- a/core/data/src/main/java/com/my/version/core/data/service/di/ServiceModule.kt
+++ b/core/data/src/main/java/com/my/version/core/data/service/di/ServiceModule.kt
@@ -3,8 +3,10 @@ package com.my.version.core.data.service.di
 import com.my.version.core.data.service.AuthService
 import com.my.version.core.data.service.CoverService
 import com.my.version.core.data.service.EvaluationService
+import com.my.version.core.data.service.LyricService
 import com.my.version.core.data.service.MusicService
 import com.my.version.core.data.service.di.qualifier.JWT
+import com.my.version.core.data.service.di.qualifier.LYRIC
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -35,4 +37,9 @@ object ServiceModule {
     @Singleton
     fun provideEvaluationService(@JWT retrofit: Retrofit): EvaluationService =
         retrofit.create(EvaluationService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideLyricService(@LYRIC retrofit: Retrofit): LyricService =
+        retrofit.create(LyricService::class.java)
 }

--- a/core/data/src/main/java/com/my/version/core/data/service/di/qualifier/RetrofitQualifier.kt
+++ b/core/data/src/main/java/com/my/version/core/data/service/di/qualifier/RetrofitQualifier.kt
@@ -5,3 +5,8 @@ import javax.inject.Qualifier
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class JWT
+
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class LYRIC

--- a/core/domain/src/main/java/com/my/version/core/domain/entity/CoverAudio.kt
+++ b/core/domain/src/main/java/com/my/version/core/domain/entity/CoverAudio.kt
@@ -6,5 +6,7 @@ data class CoverAudio(
     val createdDate: String = "",
     val audio: String = "",
     val artist: String = "",
-    val music: String = ""
+    val music: String = "",
+    val dateString: String = "",
+    val fileName: String = ""
 )

--- a/core/domain/src/main/java/com/my/version/core/domain/repository/LyricRepository.kt
+++ b/core/domain/src/main/java/com/my/version/core/domain/repository/LyricRepository.kt
@@ -1,5 +1,5 @@
 package com.my.version.core.domain.repository
 
 interface LyricRepository {
-    suspend fun getLyrics(music: String, artist: String): LinkedHashMap<Long, String>
+    suspend fun getLyrics(music: String, artist: String): Result<LinkedHashMap<Long, String>>
 }

--- a/core/domain/src/main/java/com/my/version/core/domain/repository/LyricRepository.kt
+++ b/core/domain/src/main/java/com/my/version/core/domain/repository/LyricRepository.kt
@@ -1,0 +1,5 @@
+package com.my.version.core.domain.repository
+
+interface LyricRepository {
+    suspend fun getLyrics(music: String, artist: String): LinkedHashMap<Long, String>
+}

--- a/feature/cover/src/main/java/com/my/version/feature/cover/main/CoverViewModel.kt
+++ b/feature/cover/src/main/java/com/my/version/feature/cover/main/CoverViewModel.kt
@@ -168,7 +168,7 @@ class CoverViewModel @Inject constructor(
     fun downloadAudio(cover: CoverAudio) = viewModelScope.launch {
         val encodedCoverName = Uri.encode(cover.audio)
         val downloadUri = Uri.parse(
-            "$DOWNLOAD_SCHEME://$DOWNLOAD_HOST/$DOWNLOAD_PATH?$DOWNLOAD_QUERY_FILE_NAME=${encodedCoverName}&$DOWNLOAD_QUERY_BUCKET=$DOWNLOAD_QUERY_BUCKET_VALUE"
+            "$DOWNLOAD_SCHEME://$DOWNLOAD_HOST/$DOWNLOAD_PATH?$DOWNLOAD_QUERY_FILE_NAME=${encodedCoverName}"//&$DOWNLOAD_QUERY_BUCKET=$DOWNLOAD_QUERY_BUCKET_VALUE"
         )
 
         _sideEffect.emit(
@@ -184,7 +184,5 @@ class CoverViewModel @Inject constructor(
         private const val DOWNLOAD_SCHEME = "http"
         private const val DOWNLOAD_PATH = "download"
         private const val DOWNLOAD_QUERY_FILE_NAME = "fileName"
-        private const val DOWNLOAD_QUERY_BUCKET = "bucketName"
-        private const val DOWNLOAD_QUERY_BUCKET_VALUE = "cover"
     }
 }

--- a/feature/cover/src/main/java/com/my/version/feature/cover/main/CoverViewModel.kt
+++ b/feature/cover/src/main/java/com/my/version/feature/cover/main/CoverViewModel.kt
@@ -7,6 +7,7 @@ import com.my.version.core.common.musicplayer.StreamMediaPlayer
 import com.my.version.core.common.state.UiState
 import com.my.version.core.domain.entity.CoverAudio
 import com.my.version.core.domain.repository.CoverRepository
+import com.my.version.core.domain.repository.TokenRepository
 import com.my.version.feature.cover.BuildConfig.DOWNLOAD_HOST
 import com.my.version.feature.cover.main.state.CoverUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -24,6 +25,7 @@ import javax.inject.Inject
 @HiltViewModel
 class CoverViewModel @Inject constructor(
     private val coverRepository: CoverRepository,
+    private val tokenRepository: TokenRepository,
     private val streamMediaPlayer: StreamMediaPlayer
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(CoverUiState())
@@ -166,21 +168,22 @@ class CoverViewModel @Inject constructor(
 
 
     fun downloadAudio(cover: CoverAudio) = viewModelScope.launch {
-        val encodedCoverName = Uri.encode(cover.audio)
+        //val encodedCoverName = Uri.encode(cover.fileName)
+        val outputFileName = FILE_FORMAT.format(cover.title, cover.dateString)
         val downloadUri = Uri.parse(
-            "$DOWNLOAD_SCHEME://$DOWNLOAD_HOST/$DOWNLOAD_PATH?$DOWNLOAD_QUERY_FILE_NAME=${encodedCoverName}"//&$DOWNLOAD_QUERY_BUCKET=$DOWNLOAD_QUERY_BUCKET_VALUE"
+            "$DOWNLOAD_SCHEME://$DOWNLOAD_HOST/$DOWNLOAD_PATH?$DOWNLOAD_QUERY_FILE_NAME=${cover.fileName}"
         )
-
         _sideEffect.emit(
             CoverSideEffect.DownloadAudio(
                 uri = downloadUri,
-                outputPath = cover.audio,
-                notificationTitle = cover.audio
+                outputPath = outputFileName,
+                notificationTitle = outputFileName
             )
         )
     }
 
     companion object {
+        private const val FILE_FORMAT = "%s_%s.wav"
         private const val DOWNLOAD_SCHEME = "http"
         private const val DOWNLOAD_PATH = "download"
         private const val DOWNLOAD_QUERY_FILE_NAME = "fileName"

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordScreen.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordScreen.kt
@@ -21,7 +21,6 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.my.version.core.common.extension.showToast
-import com.my.version.core.common.media.LrcConverter
 import com.my.version.core.designsystem.component.button.RectangleButton
 import com.my.version.core.designsystem.component.divider.MyVersionHorizontalDivider
 import com.my.version.core.designsystem.component.divider.TitleWithDivider
@@ -74,11 +73,12 @@ fun EvaluationRecordRoute(
     LaunchedEffect(true) {
         with(viewModel) {
             prepareMusic(uriString = musicUriString)
-            prepareMusicLyrics(
+            prepareLyrics(music = music, artist = artist)
+            /*prepareMusicLyrics(
                 lyric = LrcConverter.convertToLyricMap(
                     context.resources.openRawResource(R.raw.ditto)
                 )
-            )
+            )*/
         }
     }
 

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordViewModel.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordViewModel.kt
@@ -70,6 +70,7 @@ class EvaluationRecordViewModel @Inject constructor(
                     )
                 }
             }.onFailure {
+                it.printStackTrace()
                 _sideEffect.emit(EvaluationRecordSideEffect.ShowToast(R.string.evaluation_record_lyric_fail))
             }
     }

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordViewModel.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/record/EvaluationRecordViewModel.kt
@@ -6,8 +6,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.my.version.core.common.musicplayer.StreamMediaPlayer
 import com.my.version.core.common.watch.StopWatch
+import com.my.version.core.domain.repository.LyricRepository
 import com.my.version.core.domain.repository.RecordRepository
 import com.my.version.feature.evaluate.BuildConfig.MUSIC_STREAM_URL
+import com.my.version.feature.evaluate.R
 import com.my.version.feature.evaluate.record.state.EvaluationRecordUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -31,6 +33,7 @@ import javax.inject.Inject
 @HiltViewModel
 class EvaluationRecordViewModel @Inject constructor(
     private val recordRepository: RecordRepository,
+    private val lyricRepository: LyricRepository,
     private val streamMediaPlayer: StreamMediaPlayer
 ) : ViewModel() {
     private var _uiState = MutableStateFlow(EvaluationRecordUiState())
@@ -58,10 +61,25 @@ class EvaluationRecordViewModel @Inject constructor(
 
     }
 
-    fun prepareMusicLyrics(lyric: LinkedHashMap<Long, String>) = _uiState.update { currentState ->
-        currentState.copy(
-            songLyrics = lyric
-        )
+    fun prepareLyrics(music: String, artist: String) = viewModelScope.launch {
+        lyricRepository.getLyrics(music, artist)
+            .onSuccess { lyricMap ->
+                _uiState.update { currentState ->
+                    currentState.copy(
+                        songLyrics = lyricMap
+                    )
+                }
+            }.onFailure {
+                _sideEffect.emit(EvaluationRecordSideEffect.ShowToast(R.string.evaluation_record_lyric_fail))
+            }
+    }
+
+    fun prepareMusicLyrics(lyric: LinkedHashMap<Long, String>) {
+        _uiState.update { currentState ->
+            currentState.copy(
+                songLyrics = lyric
+            )
+        }
     }
 
     private fun onBufferingComplete() {

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/EvaluationUploadScreen.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/EvaluationUploadScreen.kt
@@ -37,10 +37,6 @@ import com.my.version.feature.evaluate.upload.state.EvaluationUploadUiState
 import timber.log.Timber
 import com.my.version.core.designsystem.R as DesignSystemR
 
-/**
- * 초 표시
- */
-
 @Composable
 fun EvaluationUploadRoute(
     coverId: Long,
@@ -48,6 +44,7 @@ fun EvaluationUploadRoute(
     artist: String,
     filePath: String,
     onNavigateToHome: () -> Unit,
+    onNavigateUp: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: EvaluationUploadViewModel = hiltViewModel()
 ) {
@@ -69,10 +66,15 @@ fun EvaluationUploadRoute(
     EvaluationUploadScreen(
         modifier = modifier,
         uiState = uiState,
-        onClickBack = {},
+        artist = artist,
+        music = music,
+        onClickBack = onNavigateUp,
         onClickUpload = { viewModel.updateUploadDialogVisibility(true) },
         onClickPlay = viewModel::playAudio,
-        onClickClose = viewModel::stopAudio,
+        onClickClose = {
+            /*TODO: X 버튼 눌렀을 때 이벤트 설정*/
+            onNavigateUp()
+        },
         onChangeSlider = viewModel::changeSlider,
     )
 
@@ -89,13 +91,15 @@ fun EvaluationUploadRoute(
 
     DisposableEffect(true) {
         onDispose {
-            /*TODO: AudioPlayer 종료*/
+            viewModel.stopAudio()
         }
     }
 }
 
 @Composable
 private fun EvaluationUploadScreen(
+    music: String,
+    artist: String,
     onClickBack: () -> Unit,
     onClickPlay: () -> Unit,
     onClickClose: () -> Unit,
@@ -118,8 +122,8 @@ private fun EvaluationUploadScreen(
         )
 
         TitleWithDivider(
-            text = stringResource(id = R.string.evaluation_on_boarding_title2),
-            textStyle = MaterialTheme.typography.titleMedium,
+            text = "$artist - $music",
+            textStyle = MaterialTheme.typography.titleSmall,
             modifier = commonModifier
         )
 
@@ -136,6 +140,10 @@ private fun EvaluationUploadScreen(
         MyVersionHorizontalDivider(
             modifier = commonModifier
         )
+
+        /**
+         * TODO: 재생시간 표시하기
+         */
 
         Slider(
             value = uiState.progress,
@@ -181,7 +189,9 @@ private fun EvaluationRecordScreenPreview() {
             onClickPlay = {},
             onChangeSlider = {},
             modifier = Modifier.background(MyVersionBackground),
-            uiState = EvaluationUploadUiState()
+            uiState = EvaluationUploadUiState(),
+            artist = "NewJeans",
+            music = "Ditto"
         )
     }
 }

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/EvaluationUploadScreen.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/EvaluationUploadScreen.kt
@@ -17,14 +17,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.my.version.core.common.media.LrcConverter
 import com.my.version.core.designsystem.component.button.RectangleButton
 import com.my.version.core.designsystem.component.dialog.ConfirmDialog
 import com.my.version.core.designsystem.component.divider.MyVersionHorizontalDivider
@@ -46,22 +44,24 @@ import com.my.version.core.designsystem.R as DesignSystemR
 @Composable
 fun EvaluationUploadRoute(
     coverId: Long,
+    music: String,
+    artist: String,
     filePath: String,
     onNavigateToHome: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: EvaluationUploadViewModel = hiltViewModel()
 ) {
-    val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle(lifecycleOwner)
 
     LaunchedEffect(true) {
         Timber.tag("StreamMediaPlayer").d(filePath)
         with(viewModel) {
-            setAudioData(
+            updateFilePath(
+                //TODO: filePath = filePath
                 filePath = "/storage/emulated/0/Android/data/com.my.version/files/Music/Ditto_NewJeans.mp3",
-                songLyrics = LrcConverter.convertToLyricMap(context.resources.openRawResource(R.raw.ditto))
             )
+            getLyrics(music, artist)
             prepareAudio()
         }
     }

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/EvaluationUploadViewModel.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/EvaluationUploadViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.my.version.core.common.state.UiState
 import com.my.version.core.domain.repository.EvaluationUploadRepository
+import com.my.version.core.domain.repository.LyricRepository
 import com.my.version.feature.evaluate.upload.state.EvaluationUploadUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -19,7 +20,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class EvaluationUploadViewModel @Inject constructor(
-    private val evaluationUploadRepository: EvaluationUploadRepository
+    private val evaluationUploadRepository: EvaluationUploadRepository,
+    private val lyricRepository: LyricRepository
 ) : ViewModel() {
     private var _uiState = MutableStateFlow(EvaluationUploadUiState())
     val uiState = _uiState.asStateFlow()
@@ -29,15 +31,26 @@ class EvaluationUploadViewModel @Inject constructor(
 
     private var mediaPlayer: MutableStateFlow<MediaPlayer?> = MutableStateFlow(null)
 
-    fun setAudioData(
-        filePath: String, songLyrics: Map<Long, String>
+    fun updateFilePath(
+        filePath: String
     ) = _uiState.update { currentState ->
         currentState.copy(
-            filePath = filePath,
-            songLyrics = songLyrics
+            filePath = filePath
         )
     }
 
+    fun getLyrics(music: String, artist: String) = viewModelScope.launch {
+        lyricRepository.getLyrics(music, artist)
+            .onSuccess { lyricMap ->
+                _uiState.update { currentState ->
+                    currentState.copy(
+                        songLyrics = lyricMap
+                    )
+                }
+            }.onFailure {
+                it.printStackTrace()
+            }
+    }
 
     fun prepareAudio() {
         try {

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/navigation/EvaluationUploadNavigation.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/navigation/EvaluationUploadNavigation.kt
@@ -25,6 +25,8 @@ fun NavGraphBuilder.evaluationUploadScreen(
         val coverId = backStackEntry.toRoute<EvaluationUpload>().coverId
 
         EvaluationUploadRoute(
+            music = "Ditto",
+            artist = "NewJeans",
             modifier = modifier,
             onNavigateToHome = navigateToEvaluationMain,
             filePath = filePath,

--- a/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/navigation/EvaluationUploadNavigation.kt
+++ b/feature/evaluate/src/main/java/com/my/version/feature/evaluate/upload/navigation/EvaluationUploadNavigation.kt
@@ -18,6 +18,7 @@ fun NavController.navigateToEvaluationUpload(
 
 fun NavGraphBuilder.evaluationUploadScreen(
     navigateToEvaluationMain: () -> Unit,
+    navigateUp: () -> Unit,
     modifier: Modifier
 ) {
     composable<EvaluationUpload> { backStackEntry ->
@@ -28,9 +29,11 @@ fun NavGraphBuilder.evaluationUploadScreen(
             music = "Ditto",
             artist = "NewJeans",
             modifier = modifier,
-            onNavigateToHome = navigateToEvaluationMain,
             filePath = filePath,
-            coverId = coverId
+            coverId = coverId,
+
+            onNavigateToHome = navigateToEvaluationMain,
+            onNavigateUp = navigateUp
         )
     }
 }

--- a/feature/evaluate/src/main/res/values/strings.xml
+++ b/feature/evaluate/src/main/res/values/strings.xml
@@ -20,6 +20,9 @@
     <string name="evaluation_select_empty">Cover Not Available</string>
     <string name="evaluation_select_empty_guide1">create cover to continue</string>
 
+    <!--Evaluation Record Screen-->
+    <string name="evaluation_record_lyric_fail">failed to load lyrics</string>
+
     <!--Evaluation Result Screen-->
     <string name="evaluation_result_similarity">Similarity</string>
     <string name="evaluation_result_similarity_1">Very Similar to AI cover</string>

--- a/feature/main/src/main/java/com/my/version/feature/main/MainNavigator.kt
+++ b/feature/main/src/main/java/com/my/version/feature/main/MainNavigator.kt
@@ -32,9 +32,11 @@ class MainNavigator(
             navController.currentDestination?.route?.let {
                 popUpTo(it) {
                     inclusive = true
+                    saveState = true
                 }
             }
             launchSingleTop = true
+            restoreState = true
         }
 
         when (tab) {

--- a/feature/main/src/main/java/com/my/version/feature/main/MainNavigator.kt
+++ b/feature/main/src/main/java/com/my/version/feature/main/MainNavigator.kt
@@ -8,9 +8,9 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
+import com.my.version.feature.auth.splash.navigation.Splash
 import com.my.version.feature.cover.main.navigation.navigateToCover
 import com.my.version.feature.evaluate.main.navigation.navigateToEvaluation
-import com.my.version.feature.evaluate.upload.navigation.EvaluationUpload
 import com.my.version.feature.home.navigation.navigateToHome
 
 class MainNavigator(
@@ -20,7 +20,7 @@ class MainNavigator(
         @Composable get() = navController
             .currentBackStackEntryAsState().value?.destination
 
-    val startDestination = EvaluationUpload("")
+    val startDestination = Splash
 
     val currentTab: MainTab?
         @Composable get() = MainTab.find { tab ->

--- a/feature/main/src/main/java/com/my/version/feature/main/MainNavigator.kt
+++ b/feature/main/src/main/java/com/my/version/feature/main/MainNavigator.kt
@@ -8,9 +8,9 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
-import com.my.version.feature.auth.splash.navigation.Splash
 import com.my.version.feature.cover.main.navigation.navigateToCover
 import com.my.version.feature.evaluate.main.navigation.navigateToEvaluation
+import com.my.version.feature.evaluate.upload.navigation.EvaluationUpload
 import com.my.version.feature.home.navigation.navigateToHome
 
 class MainNavigator(
@@ -20,7 +20,7 @@ class MainNavigator(
         @Composable get() = navController
             .currentBackStackEntryAsState().value?.destination
 
-    val startDestination = Splash
+    val startDestination = EvaluationUpload("")
 
     val currentTab: MainTab?
         @Composable get() = MainTab.find { tab ->

--- a/feature/main/src/main/java/com/my/version/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/my/version/feature/main/MainScreen.kt
@@ -141,6 +141,7 @@ private fun MyVersionNavHost(
             modifier = noBottomBarModifier
         )
         evaluationUploadScreen(
+            navigateUp = navController::navigateUp,
             navigateToEvaluationMain = navController::navigateToEvaluation,
             modifier = noBottomBarModifier
         )


### PR DESCRIPTION
- closed #58 

## 🫡 Work Done
- 평가 업로드 녹음 화면에 가사 표시
- 평가 업로드 확인 화면에 가사 표시
- 다운로드 오류 수정
  - api 변동 -> 응답 값 변경 -> 다운로드에 사용되는 쿼리 파라미터 변수 변경
 
## 📌 Note
